### PR TITLE
Port autoselect

### DIFF
--- a/Rhino.Queues.Tests/AutoSelectPort.cs
+++ b/Rhino.Queues.Tests/AutoSelectPort.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using Rhino.Mocks;
+using Rhino.Queues.Model;
+using Rhino.Queues.Protocol;
+using Rhino.Queues.Tests.Protocol;
+using Xunit;
+
+namespace Rhino.Queues.Tests
+{
+    public class AutoSelectPort : WithDebugging, IDisposable
+    {
+        private const int INITIAL_PORT = 23456;
+        private readonly IPEndPoint endPoint = new IPEndPoint(IPAddress.Loopback, INITIAL_PORT);
+        private readonly QueueManager queueManager;
+
+        public AutoSelectPort()
+        {
+            if (Directory.Exists("test.esent"))
+                Directory.Delete("test.esent", true);
+
+            queueManager = new QueueManager(endPoint, "test.esent");
+        }
+        
+        [Fact]
+        public void ShouldUseInitialPortWhenItsNotInUse()
+        {
+            queueManager.EnableEndpointPortAutoSelection();
+            queueManager.Start();
+
+            Assert.Equal(INITIAL_PORT, queueManager.Endpoint.Port);
+        }
+
+        [Fact]
+        public void ShouldThrowWhenInitialPortInUseAndAutoSelectDisabled()
+        {
+            var endPoint = new IPEndPoint(IPAddress.Loopback, INITIAL_PORT);
+
+            var listener = new TcpListener(endPoint);
+            listener.Start();
+            try
+            {
+                Assert.Throws<SocketException>(() => queueManager.Start());
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+        [Fact]
+        public void ShouldUseAlternatePortWhenInitialPortInUseAndAutoSelectEnabled()
+        {
+            var listener = new TcpListener(endPoint);
+            listener.Start();
+            try
+            {
+                queueManager.EnableEndpointPortAutoSelection();
+                queueManager.Start();
+
+                Assert.NotEqual(INITIAL_PORT, queueManager.Endpoint.Port);
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+        public void Dispose()
+        {
+            queueManager.Dispose();
+        }
+    }
+}

--- a/Rhino.Queues.Tests/Rhino.Queues.Tests.csproj
+++ b/Rhino.Queues.Tests/Rhino.Queues.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Monitoring\PerformanceCounterCategoryCreation.cs" />
     <Compile Include="Monitoring\EnablingPerformanceCounters.cs" />
     <Compile Include="Monitoring\RecordPerformanceCounters.cs" />
+    <Compile Include="AutoSelectPort.cs" />
     <Compile Include="Protocol\FakeSender.cs" />
     <Compile Include="RaisingReceivedEvents.cs" />
     <Compile Include="Errors.cs" />

--- a/Rhino.Queues/IQueueManager.cs
+++ b/Rhino.Queues/IQueueManager.cs
@@ -20,6 +20,7 @@ namespace Rhino.Queues
         string[] Queues { get; }
         event Action<Endpoint> FailedToSendMessagesTo;
         void EnablePerformanceCounters();
+        void EnableEndpointPortAutoSelection();
         void WaitForAllMessagesToBeSent();
         IQueue GetQueue(string queue);
         PersistentMessage[] GetAllMessages(string queueName, string subqueue);


### PR DESCRIPTION
Adds ability for RhinoQueues to optionally select an available port from the IANA private port range if the port initially specified is in use.  This is per conversation at https://github.com/hibernating-rhinos/rhino-esb/pull/24  Once this is merged I will update RSB to delegate port selection to RQ.

My only concern about this implementation is the assignment to .Port in receiver.cs line 52.  Technically this is a side effect.  If someone is reusing the IPEndPoint that they pass to the QueueManager, this could throw them for a loop or it could be a good thing, depending on their expectation.  I don't think its an issue but wanted to point it out.
