### PR TITLE
Remove log4net dependency

### DIFF
--- a/Rhino.Queues.Tests/Protocol/FakeSender.cs
+++ b/Rhino.Queues.Tests/Protocol/FakeSender.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Text;
-using log4net;
 using Rhino.Queues.Exceptions;
 using Rhino.Queues.Model;
 using Rhino.Queues.Protocol;
 using Rhino.Queues.Storage;
 using Wintellect.Threading.AsyncProgModel;
+using ILog = Rhino.Queues.Storage.ILog;
 
 namespace Rhino.Queues.Tests.Protocol
 {

--- a/Rhino.Queues.Tests/Protocol/WithDebugging.cs
+++ b/Rhino.Queues.Tests/Protocol/WithDebugging.cs
@@ -1,17 +1,8 @@
-using log4net.Appender;
-using log4net.Config;
-using log4net.Layout;
-
 namespace Rhino.Queues.Tests.Protocol
 {
     public class WithDebugging
     {
         static WithDebugging()
-        {
-            BasicConfigurator.Configure(new DebugAppender
-            {
-                Layout = new SimpleLayout()
-            });
-        }
+        { }
     }
 }

--- a/Rhino.Queues.Tests/Rhino.Queues.Tests.csproj
+++ b/Rhino.Queues.Tests/Rhino.Queues.Tests.csproj
@@ -41,10 +41,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\SharedLibs\Esent.Interop.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\SharedLibs\log4net.dll</HintPath>
-    </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\SharedLibs\Rhino.Mocks.dll</HintPath>
@@ -82,7 +78,6 @@
     <Compile Include="Errors.cs" />
     <Compile Include="FromUsers\FromRene.cs" />
     <Compile Include="OperationsOnUnstartedQueues.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Protocol\CanSendAndReceive.cs" />
     <Compile Include="Protocol\RecieverFailure.cs" />
     <Compile Include="Protocol\SendingFailure.cs" />
@@ -123,6 +118,9 @@
       <ProductName>Windows Installer 3.1</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Rhino.Queues/Internal/TransactionEnlistment.cs
+++ b/Rhino.Queues/Internal/TransactionEnlistment.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Transactions;
-using log4net;
+
 using Rhino.Queues.Storage;
 using Transaction = System.Transactions.Transaction;
 
@@ -11,7 +11,7 @@ namespace Rhino.Queues.Internal
 		private readonly QueueStorage queueStorage;
 		private readonly Action onCompelete;
 		private readonly Action assertNotDisposed;
-		private readonly ILog logger = LogManager.GetLogger(typeof(TransactionEnlistment));
+        private readonly ILog logger = LogManager.GetLogger(typeof(TransactionEnlistment));
 
 		public TransactionEnlistment(QueueStorage queueStorage, Action onCompelete, Action assertNotDisposed)
 		{

--- a/Rhino.Queues/Monitoring/InboundPerfomanceCounters.cs
+++ b/Rhino.Queues/Monitoring/InboundPerfomanceCounters.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using log4net;
+using Rhino.Queues.Storage;
+
 
 namespace Rhino.Queues.Monitoring
 {

--- a/Rhino.Queues/Monitoring/OutboundPerfomanceCounters.cs
+++ b/Rhino.Queues/Monitoring/OutboundPerfomanceCounters.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using log4net;
+using Rhino.Queues.Storage;
+
 
 namespace Rhino.Queues.Monitoring
 {

--- a/Rhino.Queues/Monitoring/PerformanceCategoryCreator.cs
+++ b/Rhino.Queues/Monitoring/PerformanceCategoryCreator.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
-using log4net;
+using Rhino.Queues.Storage;
+
 
 namespace Rhino.Queues.Monitoring
 {

--- a/Rhino.Queues/Monitoring/PerformanceMonitor.cs
+++ b/Rhino.Queues/Monitoring/PerformanceMonitor.cs
@@ -2,7 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Transactions;
-using log4net;
+using Rhino.Queues.Storage;
+
 
 namespace Rhino.Queues.Monitoring
 {

--- a/Rhino.Queues/Protocol/Receiver.cs
+++ b/Rhino.Queues/Protocol/Receiver.cs
@@ -5,9 +5,10 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Text;
-using log4net;
+
 using Rhino.Queues.Exceptions;
 using Rhino.Queues.Model;
+using Rhino.Queues.Storage;
 using Wintellect.Threading.AsyncProgModel;
 
 namespace Rhino.Queues.Protocol

--- a/Rhino.Queues/Protocol/Sender.cs
+++ b/Rhino.Queues/Protocol/Sender.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using log4net;
+
 using Rhino.Queues.Exceptions;
 using Rhino.Queues.Model;
 using Rhino.Queues.Storage;

--- a/Rhino.Queues/Protocol/StreamUtil.cs
+++ b/Rhino.Queues/Protocol/StreamUtil.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
-using log4net;
 using Wintellect.Threading.AsyncProgModel;
 
 namespace Rhino.Queues.Protocol

--- a/Rhino.Queues/QueueManager.cs
+++ b/Rhino.Queues/QueueManager.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Threading;
 using System.Transactions;
-using log4net;
+
 using Rhino.Queues.Internal;
 using Rhino.Queues.Model;
 using Rhino.Queues.Monitoring;

--- a/Rhino.Queues/Rhino.Queues.csproj
+++ b/Rhino.Queues/Rhino.Queues.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rhino.Queues</RootNamespace>
     <AssemblyName>Rhino.Queues</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\ayende-open-source.snk</AssemblyOriginatorKeyFile>
@@ -44,10 +44,6 @@
     <Reference Include="Esent.Interop, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\SharedLibs\Esent.Interop.dll</HintPath>
-    </Reference>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\SharedLibs\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -87,12 +83,12 @@
     <Compile Include="Model\HistoryMessage.cs" />
     <Compile Include="Model\PersistentMessageToSend.cs" />
     <Compile Include="Monitoring\TransactionalPerformanceCountersProvider.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Protocol\Endpoint.cs" />
     <Compile Include="Internal\QueuedMessagesSender.cs" />
     <Compile Include="Model\PersistentMessage.cs" />
     <Compile Include="Model\Message.cs" />
     <Compile Include="Model\MessageId.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Protocol\ProtocolConstants.cs" />
     <Compile Include="Protocol\IMessageAcceptance.cs" />
     <Compile Include="Protocol\Receiver.cs" />
@@ -141,6 +137,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Rhino.Queues/Storage/GlobalActions.cs
+++ b/Rhino.Queues/Storage/GlobalActions.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using log4net;
+
 using Microsoft.Isam.Esent.Interop;
 using Rhino.Queues.Model;
 using Rhino.Queues.Protocol;

--- a/Rhino.Queues/Storage/QueueActions.cs
+++ b/Rhino.Queues/Storage/QueueActions.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Web;
-using log4net;
+
 using Microsoft.Isam.Esent.Interop;
 using Rhino.Queues.Model;
 using Rhino.Queues.Protocol;
@@ -14,7 +14,7 @@ namespace Rhino.Queues.Storage
 
 	public class QueueActions : IDisposable
 	{
-		private readonly ILog logger = LogManager.GetLogger(typeof(QueueActions));
+        private readonly ILog logger = LogManager.GetLogger(typeof(QueueActions));
 		private readonly Session session;
 		private readonly string queueName;
 		private string[] subqueues;

--- a/Rhino.Queues/Storage/QueueStorage.cs
+++ b/Rhino.Queues/Storage/QueueStorage.cs
@@ -2,14 +2,14 @@ using System;
 using System.IO;
 using System.Runtime.ConstrainedExecution;
 using System.Threading;
-using log4net;
+
 using Microsoft.Isam.Esent.Interop;
 
 namespace Rhino.Queues.Storage
 {
 	public class QueueStorage : CriticalFinalizerObject, IDisposable
 	{
-		private readonly ILog log = LogManager.GetLogger(typeof(QueueStorage));
+        private readonly ILog log = LogManager.GetLogger(typeof(QueueStorage));
 		private JET_INSTANCE instance;
 		private readonly string database;
 		private readonly string path;

--- a/Rhino.Queues/Storage/SenderActions.cs
+++ b/Rhino.Queues/Storage/SenderActions.cs
@@ -3,16 +3,187 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Web;
-using log4net;
+
 using Microsoft.Isam.Esent.Interop;
 using Rhino.Queues.Model;
 using Rhino.Queues.Protocol;
 
 namespace Rhino.Queues.Storage
 {
+    /// <summary>
+    /// A logger.
+    /// </summary>
+    public interface ILog
+    {
+        /// <summary>
+        /// Logs the message as info.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        void Info(string message);
+
+        /// <summary>
+        /// Logs the message as a warning.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        void Warn(string message);
+
+        /// <summary>
+        /// Logs the message as a warning with the related exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        void Warn(string message, Exception exception);
+
+        /// <summary>
+        /// Logs the message as debug information.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        void Debug(string message);
+
+        /// <summary>
+        /// Logs the message as debug information with the related exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        void Debug(string message, Exception exception);
+
+        /// <summary>
+        /// Logs the message as an error.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        void Error(string message);
+
+        /// <summary>
+        /// Logs the exception.
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        void Error(Exception exception);
+
+        /// <summary>
+        /// Logs the specified message along with the related exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        void Error(string message, Exception exception);
+
+        /// <summary>
+        /// Logs the message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        void Fatal(string message);
+
+        /// <summary>
+        /// Logs the specified message along with the related exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        void Fatal(string message, Exception exception);
+    }
+
+    /// <summary>
+    /// Used to manage logging.
+    /// </summary>
+    public static class LogManager
+    {
+        static readonly ILog NullLogSingleton = new NullLog();
+        static Func<Type, ILog> _logLocator = type => NullLogSingleton;
+
+        /// <summary>
+        /// Initializes the system with the specified log creator.
+        /// </summary>
+        /// <param name="logLocator">The log locator.</param>
+        public static void Initialize(Func<Type, ILog> logLocator)
+        {
+            _logLocator = logLocator;
+        }
+
+        /// <summary>
+        /// Creates a log.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns></returns>
+        public static ILog GetLogger(Type type)
+        {
+            return _logLocator(type);
+        }
+
+        private class NullLog : ILog
+        {
+            public void Info(string message) { }
+            public void Warn(string message) { }
+            public void Warn(string message, Exception exception) { }
+            public void Debug(string message) { }
+            public void Debug(string message, Exception exception) { }
+            public void Error(string message) { }
+            public void Error(Exception exception) { }
+            public void Error(string message, Exception exception) { }
+            public void Fatal(string message) { }
+            public void Fatal(string message, Exception exception) { }
+        }
+    }
+
+    public static class LogExtensions
+    {
+        /// <summary>
+        /// Logs the message as info.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="format">The message.</param>
+        /// <param name="args">The args.</param>
+        public static void InfoFormat(this ILog log, string format, params object[] args)
+        {
+            log.Info(string.Format(format, args));
+        }
+
+        /// <summary>
+        /// Logs the message as info.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="format">The message.</param>
+        /// <param name="args">The args.</param>
+        /// <param name="e">The exception</param>
+        public static void DebugFormat(this ILog log, Exception e, string format, params object[] args)
+        {
+            log.Debug(string.Format(format, args), e);
+        }
+
+        /// <summary>
+        /// Logs the message as info.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="format">The message.</param>
+        /// <param name="args">The args.</param>
+        public static void DebugFormat(this ILog log, string format, params object[] args)
+        {
+            log.Debug(string.Format(format, args));
+        }
+
+        /// <summary>
+        /// Logs the message as a warning.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="format">The message.</param>
+        /// <param name="args">The args.</param>
+        public static void WarnFormat(this ILog log, string format, params object[] args)
+        {
+            log.Info(string.Format(format, args));
+        }
+
+        /// <summary>
+        /// Logs the message as an error.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="format">The message.</param>
+        /// <param name="args">The args.</param>
+        public static void ErrorFormat(this ILog log, string format, params object[] args)
+        {
+            log.Error(string.Format(format, args));
+        }
+    }
+
     public class SenderActions : AbstractActions
     {
-        private readonly ILog logger = LogManager.GetLogger(typeof (SenderActions));
+        private readonly ILog logger = LogManager.GetLogger(typeof(SenderActions));
 
 		public SenderActions(JET_INSTANCE instance, ColumnsInformation columnsInformation, string database, Guid instanceId)
             : base(instance, columnsInformation, database, instanceId)


### PR DESCRIPTION
Move the log4net dependency behind an ILog interface and LogManager
static class. Consumers of the library can provide their own wrapper
implementation to hook up to a logging framework of their choice.

TODO: 
- currently a null logger is registered, whereas previously logging with log4net was automatically set up.  this could be sorted out by creating an additional package that contains and registers a log4net wrapper, preserving BBB.
- the log4net binary and package spec dependency on log4net have not been adjusted.
