### PR TITLE
Added support for DeliverBy and MaxAttempts for outgoing messages.

### DIFF
--- a/Rhino.Queues.Tests/Rhino.Queues.Tests.csproj
+++ b/Rhino.Queues.Tests/Rhino.Queues.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="StartingRhinoQueues.cs" />
     <Compile Include="Storage\CanUseQueue.cs" />
     <Compile Include="ReceivingFromRhinoQueue.cs" />
+    <Compile Include="Storage\DeliveryOptions.cs" />
     <Compile Include="UsingSubQueues.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Rhino.Queues.Tests/Storage/DeliveryOptions.cs
+++ b/Rhino.Queues.Tests/Storage/DeliveryOptions.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading;
+using Rhino.Queues.Protocol;
+using Rhino.Queues.Storage;
+using Xunit;
+
+namespace Rhino.Queues.Tests.Storage
+{
+    public class DeliveryOptions
+    {
+        [Fact]
+        public void MovesExpiredMessageToOutgoingHistory()
+        {
+            using (var qf = new QueueStorage("test.esent"))
+            {
+                qf.Initialize();
+
+                qf.Global(actions =>
+                {
+                    actions.CreateQueueIfDoesNotExists("test");
+                    actions.Commit();
+                });
+
+                var testMessage = new MessagePayload{
+                    Data = new byte[0],
+                    DeliverBy = DateTime.Now.AddSeconds(-1),
+                    Headers = new NameValueCollection(),
+                    MaxAttempts = null
+                };
+
+                Guid messageId = Guid.Empty;
+                qf.Global(actions =>
+                {
+                    Guid transactionId = Guid.NewGuid();
+                    messageId = actions.RegisterToSend(new Endpoint("localhost", 0), "test", null, testMessage, transactionId);
+                    actions.MarkAsReadyToSend(transactionId);
+                    actions.Commit();
+                });
+
+                qf.Send(actions =>
+                {
+                    Endpoint endpoint;
+                    var msgs = actions.GetMessagesToSendAndMarkThemAsInFlight(int.MaxValue, int.MaxValue, out endpoint);
+                    Assert.Empty(msgs);
+                    actions.Commit();
+                });
+
+                qf.Global(actions =>
+                {
+                    var message = actions.GetSentMessages().FirstOrDefault(x => x.Id.MessageIdentifier == messageId);
+                    Assert.NotNull(message);
+                    Assert.Equal(OutgoingMessageStatus.Failed, message.OutgoingStatus);
+                    actions.Commit();
+                });
+            }
+        }
+
+        [Fact]
+        public void MovesMessageToOutgoingHistoryAfterMaxAttempts()
+        {
+            using (var qf = new QueueStorage("test.esent"))
+            {
+                qf.Initialize();
+
+                qf.Global(actions =>
+                {
+                    actions.CreateQueueIfDoesNotExists("test");
+                    actions.Commit();
+                });
+
+                var testMessage = new MessagePayload{
+                    Data = new byte[0],
+                    DeliverBy = null,
+                    Headers = new NameValueCollection(),
+                    MaxAttempts = 1
+                };
+
+                Guid messageId = Guid.Empty;
+                qf.Global(actions =>
+                {
+                    Guid transactionId = Guid.NewGuid();
+                    messageId = actions.RegisterToSend(new Endpoint("localhost", 0), "test", null, testMessage, transactionId);
+                    actions.MarkAsReadyToSend(transactionId);
+                    actions.Commit();
+                });
+
+                qf.Send(actions =>
+                {
+                    Endpoint endpoint;
+                    var msgs = actions.GetMessagesToSendAndMarkThemAsInFlight(int.MaxValue, int.MaxValue, out endpoint);
+                    actions.MarkOutgoingMessageAsFailedTransmission(msgs.First().Bookmark, false);
+
+                    // HACK: ESENT updates asynchronously, so we need to give it a chance to finish.
+                    Thread.Sleep(1000);
+
+                    msgs = actions.GetMessagesToSendAndMarkThemAsInFlight(int.MaxValue, int.MaxValue, out endpoint);
+                    actions.Commit();
+                });
+
+                qf.Global(actions =>
+                {
+                    var message = actions.GetSentMessages().FirstOrDefault(x => x.Id.MessageIdentifier == messageId);
+                    Assert.NotNull(message);
+                    Assert.Equal(OutgoingMessageStatus.Failed, message.OutgoingStatus);
+                    actions.Commit();
+                });
+            }
+        }
+    }
+}

--- a/Rhino.Queues/MessagePayload.cs
+++ b/Rhino.Queues/MessagePayload.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Specialized;
 
 namespace Rhino.Queues
@@ -10,6 +11,8 @@ namespace Rhino.Queues
         }
 
         public byte[] Data { get; set; }
+        public DateTime? DeliverBy { get; set; }
         public NameValueCollection Headers { get; set; }
+        public int? MaxAttempts { get; set; }
     }
 }

--- a/Rhino.Queues/QueueManager.cs
+++ b/Rhino.Queues/QueueManager.cs
@@ -127,7 +127,7 @@ namespace Rhino.Queues
 
 						foreach (var message in messages)
 						{
-							logger.DebugFormat("Purging message {0} from queue {0}/{1}", message.Id, message.Queue, message.SubQueue);
+							logger.DebugFormat("Purging message {0} from queue {1}/{2}", message.Id, message.Queue, message.SubQueue);
 							queueActions.DeleteHistoric(message.Bookmark);
 						}
 					}

--- a/Rhino.Queues/Storage/GlobalActions.cs
+++ b/Rhino.Queues/Storage/GlobalActions.cs
@@ -163,6 +163,11 @@ namespace Rhino.Queues.Storage
 				Api.SetColumn(session, outgoing, ColumnsInformation.OutgoingColumns["number_of_retries"], 1);
 				Api.SetColumn(session, outgoing, ColumnsInformation.OutgoingColumns["size_of_data"], payload.Data.Length);
 
+                if (payload.DeliverBy != null)
+                    Api.SetColumn(session, outgoing, ColumnsInformation.OutgoingColumns["deliver_by"], payload.DeliverBy.Value.ToOADate());
+                if (payload.MaxAttempts != null)
+                    Api.SetColumn(session, outgoing, ColumnsInformation.OutgoingColumns["max_attempts"], payload.MaxAttempts.Value);
+
                 update.Save(bookmark.Bookmark, bookmark.Size, out bookmark.Size);
             }
             Api.JetGotoBookmark(session, outgoing, bookmark.Bookmark, bookmark.Size);
@@ -204,7 +209,7 @@ namespace Rhino.Queues.Storage
                     update.Save();
                 }
                 logger.DebugFormat("Marking output message {0} as Ready",
-					Api.RetrieveColumnAsInt32(session, outgoing, ColumnsInformation.OutgoingColumns["msg_id"]).Value);
+					new Guid(Api.RetrieveColumn(session, outgoing, ColumnsInformation.OutgoingColumns["msg_id"])));
             } while (Api.TryMoveNext(session, outgoing));
         }
 
@@ -230,7 +235,7 @@ namespace Rhino.Queues.Storage
         	do
             {
                 logger.DebugFormat("Deleting output message {0}",
-					Api.RetrieveColumnAsInt32(session, outgoing, ColumnsInformation.OutgoingColumns["msg_id"]).Value);
+					new Guid(Api.RetrieveColumn(session, outgoing, ColumnsInformation.OutgoingColumns["msg_id"])));
                 Api.JetDelete(session, outgoing);
             } while (Api.TryMoveNext(session, outgoing));
         }

--- a/Rhino.Queues/Storage/SchemaCreator.cs
+++ b/Rhino.Queues/Storage/SchemaCreator.cs
@@ -7,7 +7,7 @@ namespace Rhino.Queues.Storage
     public class SchemaCreator
     {
         private readonly Session session;
-        public const string SchemaVersion = "1.9";
+        public const string SchemaVersion = "1.10";
 
         public SchemaCreator(Session session)
         {
@@ -168,6 +168,18 @@ namespace Rhino.Queues.Storage
 				grbit = ColumndefGrbit.None
             }, null, 0, out columnid);
 
+            Api.JetAddColumn(session, tableid, "deliver_by", new JET_COLUMNDEF
+            {
+                coltyp = JET_coltyp.DateTime,
+                grbit = ColumndefGrbit.ColumnFixed
+            }, null, 0, out columnid);
+
+            Api.JetAddColumn(session, tableid, "max_attempts", new JET_COLUMNDEF
+            {
+                coltyp = JET_coltyp.Long,
+                grbit = ColumndefGrbit.ColumnFixed
+            }, null, 0, out columnid);
+
             var indexDef = "+msg_id\0\0";
             Api.JetCreateIndex(session, tableid, "pk", CreateIndexGrbit.IndexPrimary, indexDef, indexDef.Length,
                                100);
@@ -272,6 +284,18 @@ namespace Rhino.Queues.Storage
                 coltyp = JET_coltyp.LongBinary,
 				// For Win2k3 support, it doesn't support long binary columsn that are not null
 				grbit = ColumndefGrbit.None
+            }, null, 0, out columnid);
+
+            Api.JetAddColumn(session, tableid, "deliver_by", new JET_COLUMNDEF
+            {
+                coltyp = JET_coltyp.DateTime,
+                grbit = ColumndefGrbit.ColumnFixed
+            }, null, 0, out columnid);
+
+            Api.JetAddColumn(session, tableid, "max_attempts", new JET_COLUMNDEF
+            {
+                coltyp = JET_coltyp.Long,
+                grbit = ColumndefGrbit.ColumnFixed
             }, null, 0, out columnid);
 
             var indexDef = "+msg_id\0\0";

--- a/Rhino.Queues/Storage/SenderActions.cs
+++ b/Rhino.Queues/Storage/SenderActions.cs
@@ -38,31 +38,6 @@ namespace Rhino.Queues.Storage
                 if (value != OutgoingMessageStatus.Ready)
                     continue;
 
-                if (time > DateTime.Now)
-                    continue;
-
-                var rowEndpoint = new Endpoint(
-                    Api.RetrieveColumnAsString(session, outgoing, ColumnsInformation.OutgoingColumns["address"]),
-                    Api.RetrieveColumnAsInt32(session, outgoing, ColumnsInformation.OutgoingColumns["port"]).Value
-                    );
-
-                if (endPoint == null)
-                    endPoint = rowEndpoint;
-
-                if (endPoint.Equals(rowEndpoint) == false)
-                    continue;
-
-				var rowQueue = Api.RetrieveColumnAsString(session, outgoing, ColumnsInformation.OutgoingColumns["queue"], Encoding.Unicode);
-
-				if (queue == null) 
-					queue = rowQueue;
-
-				if(queue != rowQueue)
-					continue;
-                
-                var bookmark = new MessageBookmark();
-                Api.JetGetBookmark(session, outgoing, bookmark.Bookmark, bookmark.Size, out bookmark.Size);
-
                 // Check if the message has expired, and move it to the outgoing history.
                 var deliverBy = Api.RetrieveColumnAsDouble(session, outgoing, ColumnsInformation.OutgoingColumns["deliver_by"]);
                 if (deliverBy != null)
@@ -89,6 +64,30 @@ namespace Rhino.Queues.Storage
                     }
                 }
 
+                if (time > DateTime.Now)
+                    continue;
+
+                var rowEndpoint = new Endpoint(
+                    Api.RetrieveColumnAsString(session, outgoing, ColumnsInformation.OutgoingColumns["address"]),
+                    Api.RetrieveColumnAsInt32(session, outgoing, ColumnsInformation.OutgoingColumns["port"]).Value
+                    );
+
+                if (endPoint == null)
+                    endPoint = rowEndpoint;
+
+                if (endPoint.Equals(rowEndpoint) == false)
+                    continue;
+
+				var rowQueue = Api.RetrieveColumnAsString(session, outgoing, ColumnsInformation.OutgoingColumns["queue"], Encoding.Unicode);
+
+				if (queue == null) 
+					queue = rowQueue;
+
+				if(queue != rowQueue)
+					continue;
+                
+                var bookmark = new MessageBookmark();
+                Api.JetGetBookmark(session, outgoing, bookmark.Bookmark, bookmark.Size, out bookmark.Size);
 
                 logger.DebugFormat("Adding message {0} to returned messages", msgId);
                 var headerAsQueryString = Api.RetrieveColumnAsString(session, outgoing, ColumnsInformation.OutgoingColumns["headers"],Encoding.Unicode);

--- a/default.ps1
+++ b/default.ps1
@@ -6,7 +6,7 @@ properties {
   $40_build_dir = "$build_dir\4.0\"
   $35_build_dir = "$build_dir\3.5\"
   $sln_file = "$base_dir\Rhino.Queues.sln" 
-  $version = "1.4.2.0"
+  $version = "2.0.0.0"
   $config = "Release"
   $tools_dir = "$base_dir\Tools"
   $release_dir = "$base_dir\Release"


### PR DESCRIPTION
Includes an update to the ESENT schema to add the two delivery options to the Outgoing and OutgoingHistory tables.

There were a few places the message ID was retrieved as an int instead of a Guid that I also fixed.
