### PR TITLE
Fixed SenderActions.RevertBackToSend()...

### DIFF
--- a/Rhino.Queues.Tests/Protocol/FakeReceiver.cs
+++ b/Rhino.Queues.Tests/Protocol/FakeReceiver.cs
@@ -6,7 +6,7 @@ using Rhino.Queues.Protocol;
 
 namespace Rhino.Queues.Tests.Protocol
 {
-    public class FakeReciever
+    public class FakeReceiver
     {
         private readonly TcpListener listener = new TcpListener(new IPEndPoint(IPAddress.Loopback, 23456));
 

--- a/Rhino.Queues.Tests/Protocol/SendingFailure.cs
+++ b/Rhino.Queues.Tests/Protocol/SendingFailure.cs
@@ -43,7 +43,7 @@ namespace Rhino.Queues.Tests.Protocol
         }
 
         [Fact]
-        public void CanHandleItWhenRecieverDoesNotExists()
+        public void CanHandleItWhenReceiverDoesNotExists()
         {
             sender.Send();
             wait.WaitOne();
@@ -53,9 +53,9 @@ namespace Rhino.Queues.Tests.Protocol
         }
 
         [Fact]
-        public void CanHandleItWhenRecieverConnectAndDisconnect()
+        public void CanHandleItWhenReceiverConnectAndDisconnect()
         {
-            new FakeReciever { DisconnectAfterConnect = true }.Start();
+            new FakeReceiver { DisconnectAfterConnect = true }.Start();
 
             sender.Send();
             wait.WaitOne();
@@ -65,9 +65,9 @@ namespace Rhino.Queues.Tests.Protocol
         }
 
         [Fact]
-        public void CanHandleItWhenRecieverDisconnectDuringRecieve()
+        public void CanHandleItWhenReceiverDisconnectDuringRecieve()
         {
-            new FakeReciever { DisconnectDuringMessageSend = true }.Start();
+            new FakeReceiver { DisconnectDuringMessageSend = true }.Start();
 
             sender.Send();
             wait.WaitOne();
@@ -77,9 +77,9 @@ namespace Rhino.Queues.Tests.Protocol
         }
 
         [Fact]
-        public void CanHandleItWhenRecieverDisconnectAfterRecieve()
+        public void CanHandleItWhenReceiverDisconnectAfterRecieve()
         {
-            new FakeReciever { DisconnectAfterMessageSend = true }.Start();
+            new FakeReceiver { DisconnectAfterMessageSend = true }.Start();
 
             sender.Send();
             wait.WaitOne();
@@ -89,9 +89,9 @@ namespace Rhino.Queues.Tests.Protocol
         }
 
         [Fact]
-        public void CanHandleItWhenRecieverSendingBadResponse()
+        public void CanHandleItWhenReceiverSendingBadResponse()
         {
-            new FakeReciever { SendBadResponse = true }.Start();
+            new FakeReceiver { SendBadResponse = true }.Start();
 
             sender.Send();
             wait.WaitOne();
@@ -101,9 +101,9 @@ namespace Rhino.Queues.Tests.Protocol
         }
 
         [Fact]
-        public void CanHandleItWhenRecieverDisconnectAfterSendingRecieved()
+        public void CanHandleItWhenReceiverDisconnectAfterSendingRecieved()
         {
-            new FakeReciever { DisconnectAfterSendingReciept = true }.Start();
+            new FakeReceiver { DisconnectAfterSendingReciept = true }.Start();
 
             sender.Send();
             wait.WaitOne();
@@ -111,7 +111,7 @@ namespace Rhino.Queues.Tests.Protocol
             // this is a scenario where we actually have 
             // a false positive, this is an edge case that
             // we tolerate, since a message is not actually 
-            // lost, but merely undeliverable in the reciever 
+            // lost, but merely undeliverable in the receiver 
             // queue.
 
             Assert.False(failureReported);
@@ -119,15 +119,15 @@ namespace Rhino.Queues.Tests.Protocol
         }
 
         [Fact]
-        public void CanHandleItWhenRecieverSendRevert()
+        public void CanHandleItWhenReceiverSendRevert()
         {
-            new FakeReciever { FailOnAcknowledgement = true }.Start();
+            new FakeReceiver { FailOnAcknowledgement = true }.Start();
 
             sender.Send();
             wait.WaitOne();
 
             // this is a case where we create compensation
-            // for reported failure on the reciever side
+            // for reported failure on the Receiver side
 
             Assert.False(failureReported);
             Assert.True(wasSuccessful);

--- a/Rhino.Queues.Tests/Rhino.Queues.Tests.csproj
+++ b/Rhino.Queues.Tests/Rhino.Queues.Tests.csproj
@@ -86,7 +86,7 @@
     <Compile Include="Protocol\CanSendAndReceive.cs" />
     <Compile Include="Protocol\RecieverFailure.cs" />
     <Compile Include="Protocol\SendingFailure.cs" />
-    <Compile Include="Protocol\FakeReciever.cs" />
+    <Compile Include="Protocol\FakeReceiver.cs" />
     <Compile Include="Protocol\WithDebugging.cs" />
     <Compile Include="FromUsers\QueueIsAsync.cs" />
     <Compile Include="RaisingSendEvents.cs" />
@@ -95,6 +95,7 @@
     <Compile Include="Storage\CanUseQueue.cs" />
     <Compile Include="ReceivingFromRhinoQueue.cs" />
     <Compile Include="Storage\DeliveryOptions.cs" />
+    <Compile Include="Storage\RevertBackToSend.cs" />
     <Compile Include="UsingSubQueues.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Rhino.Queues.Tests/Storage/RevertBackToSend.cs
+++ b/Rhino.Queues.Tests/Storage/RevertBackToSend.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.IO;
+using Rhino.Queues.Protocol;
+using Rhino.Queues.Storage;
+using Xunit;
+
+namespace Rhino.Queues.Tests.Storage
+{
+    public class RevertBackToSend
+    {
+        public RevertBackToSend()
+        {
+            if (Directory.Exists("test.esent"))
+                Directory.Delete("test.esent", true);
+        }
+
+        [Fact]
+        public void MovesMessageToOutgoingFromHistory()
+        {
+            using (var qf = new QueueStorage("test.esent"))
+            {
+                qf.Initialize();
+                qf.Global(actions =>
+                {
+                    actions.CreateQueueIfDoesNotExists("test");
+                    actions.Commit();
+                });
+
+                var testMessage = new MessagePayload
+                {
+                    Data = new byte[0],
+                    Headers = new NameValueCollection(),
+                };
+
+                qf.Global(actions =>
+                {
+                    Guid transactionId = Guid.NewGuid();
+                    actions.RegisterToSend(new Endpoint("localhost", 0),
+                        "test",
+                        null,
+                        testMessage,
+                        transactionId);
+                    actions.MarkAsReadyToSend(transactionId);
+                    actions.Commit();
+                });
+
+                qf.Send(actions =>
+                {
+                    Endpoint endpoint;
+                    var msgs = actions.GetMessagesToSendAndMarkThemAsInFlight(int.MaxValue, int.MaxValue, out endpoint);
+                    var bookmark = actions.MarkOutgoingMessageAsSuccessfullySent(msgs[0].Bookmark);
+                    actions.RevertBackToSend(new[] { bookmark });
+
+                    msgs = actions.GetMessagesToSendAndMarkThemAsInFlight(int.MaxValue, int.MaxValue, out endpoint);
+                    Assert.NotEmpty(msgs);
+                    actions.Commit();
+                });
+
+                qf.Global(actions =>
+                {
+                    var messages = actions.GetSentMessages();
+                    Assert.Empty(messages);
+                    actions.Commit();
+                });
+            }
+        }
+    }
+}

--- a/Rhino.Queues/Storage/SenderActions.cs
+++ b/Rhino.Queues/Storage/SenderActions.cs
@@ -217,7 +217,7 @@ namespace Rhino.Queues.Storage
             foreach (var bookmark in bookmarks)
             {
                 Api.JetGotoBookmark(session, outgoingHistory, bookmark.Bookmark, bookmark.Size);
-                var msgId = new Guid(Api.RetrieveColumn(session, outgoing, ColumnsInformation.OutgoingColumns["msg_id"]));
+                var msgId = new Guid(Api.RetrieveColumn(session, outgoingHistory, ColumnsInformation.OutgoingColumns["msg_id"]));
 
                 using(var update = new  Update(session, outgoing, JET_prep.Insert))
                 {
@@ -237,6 +237,7 @@ namespace Rhino.Queues.Storage
 
                     update.Save();
                 }
+                Api.JetDelete(session, outgoingHistory);
             }
         }
 


### PR DESCRIPTION
...so messages are correctly moved back to the outgoing table and removed from history.  A new unit test was added for it too.
