### PR TITLE
Split PurgeOldData() into smaller transactions

### DIFF
--- a/Rhino.Queues.Tests/PurgingQueues.cs
+++ b/Rhino.Queues.Tests/PurgingQueues.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using System.Transactions;
+using Xunit;
+
+namespace Rhino.Queues.Tests
+{
+    public class PurgingQueues
+    {
+        private const string EsentFileName = "test.esent";
+        private QueueManager queueManager;
+
+        public PurgingQueues()
+        {
+            if (Directory.Exists(EsentFileName))
+                Directory.Delete(EsentFileName, true);
+        }
+
+        [Fact(Skip = "This is a slow load test")]
+        public void CanPurgeLargeSetsOfOldData()
+        {
+            queueManager = new QueueManager(new IPEndPoint(IPAddress.Loopback, 23456), EsentFileName);
+            queueManager.Configuration.OldestMessageInOutgoingHistory = TimeSpan.Zero;
+            queueManager.Start();
+
+            // Seed the queue with historical messages to be purged
+            Parallel.For(0, 1000, new ParallelOptions { MaxDegreeOfParallelism = 8 }, i => SendMessages());
+
+            queueManager.WaitForAllMessagesToBeSent();
+
+            // Try to purge while still sending new messages.
+            var purgeTask = Task.Factory.StartNew(() =>
+            {
+                queueManager.PurgeOldData();
+                Console.WriteLine("Finished purging data");
+            });
+            Parallel.For(0, 10000, new ParallelOptions { MaxDegreeOfParallelism = 8 }, i => SendMessages());
+
+            purgeTask.Wait();
+            queueManager.WaitForAllMessagesToBeSent();
+
+            queueManager.PurgeOldData();
+
+            Assert.Equal(queueManager.Configuration.NumberOfMessagesToKeepInOutgoingHistory,
+                queueManager.GetAllSentMessages().Length);
+        }
+
+        private void SendMessages()
+        {
+            using (var scope = new TransactionScope())
+            {
+                for (int j = 0; j < 100; j++)
+                {
+                    queueManager.Send(new Uri("rhino.queues://" + queueManager.Endpoint),
+                        new MessagePayload { Data = new byte[0] });
+                }
+                scope.Complete();
+            }
+        }
+    }
+}

--- a/Rhino.Queues.Tests/PurgingQueues.cs
+++ b/Rhino.Queues.Tests/PurgingQueues.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Diagnostics;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Threading.Tasks;
+using System.Threading;
 using System.Transactions;
 using Xunit;
 
@@ -27,25 +27,56 @@ namespace Rhino.Queues.Tests
             queueManager.Start();
 
             // Seed the queue with historical messages to be purged
-            Parallel.For(0, 1000, new ParallelOptions { MaxDegreeOfParallelism = 8 }, i => SendMessages());
+            QueueMessagesThreaded(1000);
+            //Parallel.For(0, 1000, new ParallelOptions { MaxDegreeOfParallelism = 8 }, i => SendMessages());
 
             queueManager.WaitForAllMessagesToBeSent();
 
             // Try to purge while still sending new messages.
-            var purgeTask = Task.Factory.StartNew(() =>
+            var waitHandle = new ManualResetEvent(false);
+            ThreadPool.QueueUserWorkItem(_ =>
             {
                 queueManager.PurgeOldData();
                 Console.WriteLine("Finished purging data");
+                waitHandle.Set();
             });
-            Parallel.For(0, 10000, new ParallelOptions { MaxDegreeOfParallelism = 8 }, i => SendMessages());
+            QueueMessagesThreaded(10000);
+            //var purgeTask = Task.Factory.StartNew(() =>
+            //{
+            //    queueManager.PurgeOldData();
+            //    Console.WriteLine("Finished purging data");
+            //});
+            //Parallel.For(0, 10000, new ParallelOptions { MaxDegreeOfParallelism = 8 }, i => SendMessages());
 
-            purgeTask.Wait();
+            waitHandle.WaitOne();
+            //purgeTask.Wait();
             queueManager.WaitForAllMessagesToBeSent();
 
             queueManager.PurgeOldData();
 
             Assert.Equal(queueManager.Configuration.NumberOfMessagesToKeepInOutgoingHistory,
                 queueManager.GetAllSentMessages().Length);
+        }
+
+        private void QueueMessagesThreaded(int iterations)
+        {
+            const int threadCount = 8;
+            int iterationsPerThread = iterations / threadCount;
+            var threads = new List<Thread>();
+            for (int i = 0; i < threadCount; i++)
+            {
+                var thread = new Thread(() =>
+                {
+                    for (int j = 0; j < iterationsPerThread; j++)
+                    {
+                        SendMessages();
+                    }
+                });
+                thread.Start();
+                threads.Add(thread);
+            }
+
+            threads.ForEach(x => x.Join());
         }
 
         private void SendMessages()

--- a/Rhino.Queues.Tests/Rhino.Queues.Tests.csproj
+++ b/Rhino.Queues.Tests/Rhino.Queues.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Monitoring\RecordPerformanceCounters.cs" />
     <Compile Include="AutoSelectPort.cs" />
     <Compile Include="Protocol\FakeSender.cs" />
+    <Compile Include="PurgingQueues.cs" />
     <Compile Include="RaisingReceivedEvents.cs" />
     <Compile Include="Errors.cs" />
     <Compile Include="FromUsers\FromRene.cs" />

--- a/Rhino.Queues.Tests/Storage/CanUseQueue.cs
+++ b/Rhino.Queues.Tests/Storage/CanUseQueue.cs
@@ -19,16 +19,16 @@ namespace Rhino.Queues.Tests.Storage
         [Fact]
         public void CanCreateNewQueueFactory()
         {
-            using (var qf = new QueueStorage("test.esent"))
+            using (var qf = CreateQueueStorage())
             {
                 qf.Initialize();
             }
         }
 
-		[Fact]
+	    [Fact]
 		public void CanRegisterReceivedMessageIds()
 		{
-			using (var qf = new QueueStorage("test.esent"))
+			using (var qf = CreateQueueStorage())
 			{
 				qf.Initialize();
 
@@ -53,7 +53,7 @@ namespace Rhino.Queues.Tests.Storage
 		[Fact]
 		public void CanDeleteOldEntries()
 		{
-			using (var qf = new QueueStorage("test.esent"))
+			using (var qf = CreateQueueStorage())
 			{
 				qf.Initialize();
 
@@ -96,7 +96,7 @@ namespace Rhino.Queues.Tests.Storage
 		[Fact]
 		public void CallingDeleteOldEntriesIsSafeIfThereAreNotEnoughEntries()
 		{
-			using (var qf = new QueueStorage("test.esent"))
+			using (var qf = CreateQueueStorage())
 			{
 				qf.Initialize();
 
@@ -136,7 +136,7 @@ namespace Rhino.Queues.Tests.Storage
         [Fact]
         public void CanPutSingleMessageInQueue()
         {
-            using (var qf = new QueueStorage("test.esent"))
+            using (var qf = CreateQueueStorage())
             {
                 qf.Initialize();
 
@@ -184,7 +184,7 @@ namespace Rhino.Queues.Tests.Storage
         [Fact]
         public void WillGetMessagesBackInOrder()
         {
-            using (var qf = new QueueStorage("test.esent"))
+            using (var qf = CreateQueueStorage())
             {
                 qf.Initialize();
 
@@ -246,7 +246,7 @@ namespace Rhino.Queues.Tests.Storage
         [Fact]
         public void WillNotGiveMessageToTwoClient()
         {
-            using (var qf = new QueueStorage("test.esent"))
+            using (var qf = CreateQueueStorage())
             {
                 qf.Initialize();
 
@@ -300,7 +300,7 @@ namespace Rhino.Queues.Tests.Storage
         [Fact]
         public void WillGiveNullWhenNoItemsAreInQueue()
         {
-            using (var qf = new QueueStorage("test.esent"))
+            using (var qf = CreateQueueStorage())
             {
                 qf.Initialize();
                
@@ -317,6 +317,11 @@ namespace Rhino.Queues.Tests.Storage
                     actions.Commit();
                 });
             }
+        }
+
+        private static QueueStorage CreateQueueStorage()
+        {
+            return new QueueStorage("test.esent", new QueueManagerConfiguration());
         }
     }
 }

--- a/Rhino.Queues.Tests/Storage/CanUseQueue.cs
+++ b/Rhino.Queues.Tests/Storage/CanUseQueue.cs
@@ -77,7 +77,7 @@ namespace Rhino.Queues.Tests.Storage
 				
 				qf.Global(actions =>
 				{
-					actions.DeleteOldestReceivedMessages(6).ToArray();//consume & activate
+					actions.DeleteOldestReceivedMessageIds(6, 10).ToArray();//consume & activate
 
 					actions.Commit();
 				});
@@ -115,7 +115,7 @@ namespace Rhino.Queues.Tests.Storage
 
 				qf.Global(actions =>
 				{
-					actions.DeleteOldestReceivedMessages(10).ToArray();//consume & activate
+					actions.DeleteOldestReceivedMessageIds(10, 10).ToArray();//consume & activate
 
 					actions.Commit();
 				});

--- a/Rhino.Queues.Tests/Storage/DeliveryOptions.cs
+++ b/Rhino.Queues.Tests/Storage/DeliveryOptions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using Rhino.Queues.Model;
 using Rhino.Queues.Protocol;
 using Rhino.Queues.Storage;
@@ -15,7 +14,7 @@ namespace Rhino.Queues.Tests.Storage
         [Fact]
         public void MovesExpiredMessageToOutgoingHistory()
         {
-            using (var qf = new QueueStorage("test.esent"))
+            using (var qf = new QueueStorage("test.esent", new QueueManagerConfiguration()))
             {
                 qf.Initialize();
 
@@ -63,7 +62,7 @@ namespace Rhino.Queues.Tests.Storage
         public void MovesMessageToOutgoingHistoryAfterMaxAttempts()
         {
             Directory.Delete("test.esent", true);
-            using (var qf = new QueueStorage("test.esent"))
+            using (var qf = new QueueStorage("test.esent", new QueueManagerConfiguration()))
             {
                 qf.Initialize();
                 qf.Global(actions =>

--- a/Rhino.Queues.Tests/Storage/RevertBackToSend.cs
+++ b/Rhino.Queues.Tests/Storage/RevertBackToSend.cs
@@ -18,7 +18,7 @@ namespace Rhino.Queues.Tests.Storage
         [Fact]
         public void MovesMessageToOutgoingFromHistory()
         {
-            using (var qf = new QueueStorage("test.esent"))
+            using (var qf = new QueueStorage("test.esent", new QueueManagerConfiguration()))
             {
                 qf.Initialize();
                 qf.Global(actions =>

--- a/Rhino.Queues/IQueueManager.cs
+++ b/Rhino.Queues/IQueueManager.cs
@@ -5,16 +5,9 @@ using Rhino.Queues.Protocol;
 
 namespace Rhino.Queues
 {
-    /// <summary>
-    /// 
-    /// </summary>
     public interface IQueueManager : IDisposable
     {
-        int NumberOfReceivedMessagesToKeep { get; set; }
-        int? NumberOfMessagesToKeepInProcessedQueues { get; set; }
-        int? NumberOfMessagesToKeepOutgoingQueues { get; set; }
-        TimeSpan? OldestMessageInProcessedQueues { get; set; }
-        TimeSpan? OldestMessageInOutgoingQueues { get; set; }
+        QueueManagerConfiguration Configuration { get; set; }
         string Path { get; }
         IPEndPoint Endpoint { get; }
         string[] Queues { get; }

--- a/Rhino.Queues/QueueManager.cs
+++ b/Rhino.Queues/QueueManager.cs
@@ -121,7 +121,7 @@ namespace Rhino.Queues
 
         public void PurgeOldData()
 		{
-			logger.DebugFormat("Starting to purge old data");
+			logger.Info("Starting to purge old data");
 			try
 			{
                 PurgeProcessedMessages();
@@ -182,6 +182,7 @@ namespace Rhino.Queues
 
         private void PurgeOldestReceivedMessageIds()
         {
+            int totalCount = 0;
             List<MessageId> deletedMessageIds = null;
             do
             {
@@ -191,7 +192,10 @@ namespace Rhino.Queues
                     actions.Commit();
                 });
                 receivedMsgs.Remove(deletedMessageIds);
+                totalCount += deletedMessageIds.Count;
             } while (deletedMessageIds.Count > 0);
+
+            logger.InfoFormat("Purged {0} message ids", totalCount);
         }
 
 	    private void HandleRecovery()

--- a/Rhino.Queues/QueueManager.cs
+++ b/Rhino.Queues/QueueManager.cs
@@ -12,59 +12,55 @@ using Rhino.Queues.Protocol;
 using Rhino.Queues.Storage;
 using System.Linq;
 
+#pragma warning disable 420
 namespace Rhino.Queues
 {
-	using Exceptions;
-	using Utils;
+    using Exceptions;
+    using Utils;
 
-	public class QueueManager : IQueueManager
-	{
-		[ThreadStatic]
-		private static TransactionEnlistment Enlistment;
+    public class QueueManager : IQueueManager
+    {
+        [ThreadStatic]
+        private static TransactionEnlistment Enlistment;
 
-		[ThreadStatic]
-		private static Transaction CurrentlyEnslistedTransaction;
+        [ThreadStatic]
+        private static Transaction CurrentlyEnslistedTransaction;
 
         private volatile bool wasStarted;
         private volatile bool wasDisposed;
         private volatile bool enableEndpointPortAutoSelection;
-		private volatile int currentlyInCriticalReceiveStatus;
-		private volatile int currentlyInsideTransaction;
-		private readonly IPEndPoint endpoint;
-		private readonly object newMessageArrivedLock = new object();
-		private readonly string path;
-		private Timer purgeOldDataTimer;
-		private readonly QueueStorage queueStorage;
+        private volatile int currentlyInCriticalReceiveStatus;
+        private volatile int currentlyInsideTransaction;
+        private readonly IPEndPoint endpoint;
+        private readonly object newMessageArrivedLock = new object();
+        private readonly string path;
+        private Timer purgeOldDataTimer;
+        private readonly QueueStorage queueStorage;
 
         private Receiver receiver;
-		private Thread sendingThread;
-		private QueuedMessagesSender queuedMessagesSender;
+        private Thread sendingThread;
+        private QueuedMessagesSender queuedMessagesSender;
         private readonly ILog logger = LogManager.GetLogger(typeof(QueueManager));
         private PerformanceMonitor monitor;
         private volatile bool waitingForAllMessagesToBeSent;
 
 
-		private readonly ThreadSafeSet<MessageId> receivedMsgs = new ThreadSafeSet<MessageId>();
-		private bool disposing;
+        private readonly ThreadSafeSet<MessageId> receivedMsgs = new ThreadSafeSet<MessageId>();
+        private bool disposing;
 
-	    public int NumberOfReceivedMessagesToKeep { get; set; }
-		public int? NumberOfMessagesToKeepInProcessedQueues { get; set; }
-		public int? NumberOfMessagesToKeepOutgoingQueues { get; set; }
+        public QueueManagerConfiguration Configuration { get; set; }
 
-	    public int CurrentlySendingCount
-	    {
+        public int CurrentlySendingCount
+        {
             get { return queuedMessagesSender.CurrentlySendingCount; }
-	    }
+        }
 
-	    public int CurrentlyConnectingCount
-	    {
+        public int CurrentlyConnectingCount
+        {
             get { return queuedMessagesSender.CurrentlyConnectingCount; }
-	    }
+        }
 
-		public TimeSpan? OldestMessageInProcessedQueues { get; set; }
-		public TimeSpan? OldestMessageInOutgoingQueues { get; set; }
-
-		public event Action<Endpoint> FailedToSendMessagesTo;
+        public event Action<Endpoint> FailedToSendMessagesTo;
 
         public event Action<object, MessageEventArgs> MessageQueuedForSend;
 
@@ -72,34 +68,35 @@ namespace Rhino.Queues
         public event Action<object, MessageEventArgs> MessageQueuedForReceive;
         public event Action<object, MessageEventArgs> MessageReceived;
 
-		public QueueManager(IPEndPoint endpoint, string path)
-		{
-			NumberOfMessagesToKeepInProcessedQueues = 100;
-			NumberOfMessagesToKeepOutgoingQueues = 100;
-			NumberOfReceivedMessagesToKeep = 100000;
-			OldestMessageInProcessedQueues = TimeSpan.FromDays(3);
-			OldestMessageInOutgoingQueues = TimeSpan.FromDays(3);
+        public QueueManager(IPEndPoint endpoint, string path)
+            : this(endpoint, path, new QueueManagerConfiguration())
+        {
+        }
 
-			this.endpoint = endpoint;
-			this.path = path;
-			queueStorage = new QueueStorage(path);
-			queueStorage.Initialize();
+        public QueueManager(IPEndPoint endpoint, string path, QueueManagerConfiguration configuration)
+        {
+            Configuration = configuration;
 
-			queueStorage.Global(actions =>
-			{
-				receivedMsgs.Add(actions.GetAlreadyReceivedMessageIds());
+            this.endpoint = endpoint;
+            this.path = path;
+            queueStorage = new QueueStorage(path, configuration);
+            queueStorage.Initialize();
 
-				actions.Commit();
-			});
+            queueStorage.Global(actions =>
+            {
+                receivedMsgs.Add(actions.GetAlreadyReceivedMessageIds());
 
-			HandleRecovery();
-		}
+                actions.Commit();
+            });
+
+            HandleRecovery();
+        }
 
         public void Start()
         {
             AssertNotDisposedOrDisposing();
 
-            if(wasStarted)
+            if (wasStarted)
                 throw new InvalidOperationException("The Start method may not be invoked more than once.");
 
             receiver = new Receiver(endpoint, enableEndpointPortAutoSelection, AcceptMessages);
@@ -120,64 +117,125 @@ namespace Rhino.Queues
         }
 
         public void PurgeOldData()
-		{
-			logger.Info("Starting to purge old data");
-			try
-			{
+        {
+            logger.Info("Starting to purge old data");
+            try
+            {
                 PurgeProcessedMessages();
                 PurgeOutgoingHistory();
                 PurgeOldestReceivedMessageIds();
-			}
-			catch (Exception exception)
-			{
-				logger.Warn("Failed to purge old data from the system", exception);
-			}
-		}
+            }
+            catch (Exception exception)
+            {
+                logger.Warn("Failed to purge old data from the system", exception);
+            }
+        }
 
         private void PurgeProcessedMessages()
         {
+            if (!Configuration.EnableProcessedMessageHistory)
+                return;
+
             foreach (string queue in Queues)
+            {
+                PurgeProcessedMessagesInQueue(queue);
+            }
+        }
+
+        private void PurgeProcessedMessagesInQueue(string queue)
+        {
+            // To make this batchable:
+            // 1: Move to the end of the history (to the newest messages) and seek 
+            //    backword by NumberOfMessagesToKeepInProcessedHistory.
+            // 2: Save a bookmark of the current position.
+            // 3: Delete from the beginning of the table (oldest messages) in batches until 
+            //    a) we reach the bookmark or b) we hit OldestMessageInProcessedHistory.
+            MessageBookmark purgeLimit = null;
+            int numberOfMessagesToKeep = Configuration.NumberOfMessagesToKeepInProcessedHistory;
+            if (numberOfMessagesToKeep > 0)
             {
                 queueStorage.Global(actions =>
                 {
                     var queueActions = actions.GetQueue(queue);
-                    var messages = queueActions.GetAllProcessedMessages();
-                    if (NumberOfMessagesToKeepInProcessedQueues != null)
-                        messages = messages.Skip(NumberOfMessagesToKeepInProcessedQueues.Value);
-                    if (OldestMessageInProcessedQueues != null)
-                        messages = messages.Where(x => (DateTime.Now - x.SentAt) > OldestMessageInProcessedQueues.Value);
+                    purgeLimit = queueActions.GetMessageHistoryBookmarkAtPosition(numberOfMessagesToKeep);
+                    actions.Commit();
+                });
+
+                if (purgeLimit == null)
+                    return;
+            }
+
+            bool foundMessages = false;
+            do
+            {
+                foundMessages = false;
+                queueStorage.Global(actions =>
+                {
+                    var queueActions = actions.GetQueue(queue);
+                    var messages = queueActions.GetAllProcessedMessages(batchSize: 250)
+                        .TakeWhile(x => (purgeLimit == null || !x.Bookmark.Equals(purgeLimit))
+                            && (DateTime.Now - x.SentAt) > Configuration.OldestMessageInProcessedHistory);
 
                     foreach (var message in messages)
                     {
+                        foundMessages = true;
                         logger.DebugFormat("Purging message {0} from queue {1}/{2}", message.Id, message.Queue, message.SubQueue);
                         queueActions.DeleteHistoric(message.Bookmark);
                     }
 
                     actions.Commit();
                 });
-            }
+            } while (foundMessages);
         }
 
         private void PurgeOutgoingHistory()
         {
-            queueStorage.Global(actions =>
+            // Outgoing messages are still stored in the history in case the sender 
+            // needs to revert, so there will still be messages to purge even when
+            // the QueueManagerConfiguration has disabled outgoing history.
+            //
+            // To make this batchable:
+            // 1: Move to the end of the history (to the newest messages) and seek 
+            //    backword by NumberOfMessagesToKeepInOutgoingHistory.
+            // 2: Save a bookmark of the current position.
+            // 3: Delete from the beginning of the table (oldest messages) in batches until 
+            //    a) we reach the bookmark or b) we hit OldestMessageInOutgoingHistory.
+
+            MessageBookmark purgeLimit = null;
+            int numberOfMessagesToKeep = Configuration.NumberOfMessagesToKeepInOutgoingHistory;
+            if (numberOfMessagesToKeep > 0 && Configuration.EnableOutgoingMessageHistory)
             {
-                var sentMessages = actions.GetSentMessages();
-
-                if (NumberOfMessagesToKeepOutgoingQueues != null)
-                    sentMessages = sentMessages.Skip(NumberOfMessagesToKeepOutgoingQueues.Value);
-                if (OldestMessageInOutgoingQueues != null)
-                    sentMessages = sentMessages.Where(x => (DateTime.Now - x.SentAt) > OldestMessageInOutgoingQueues.Value);
-
-                foreach (var sentMessage in sentMessages)
+                queueStorage.Global(actions =>
                 {
-                    logger.DebugFormat("Purging sent message {0} to {1}/{2}/{3}", sentMessage.Id, sentMessage.Endpoint,
-                                       sentMessage.Queue, sentMessage.SubQueue);
-                    actions.DeleteMessageToSendHistoric(sentMessage.Bookmark);
-                }
+                    purgeLimit = actions.GetSentMessageBookmarkAtPosition(numberOfMessagesToKeep);
+                    actions.Commit();
+                });
 
-                actions.Commit();
-            });
+                if (purgeLimit == null)
+                    return;
+            }
+
+            bool foundMessages = false;
+            do
+            {
+                foundMessages = false;
+                queueStorage.Global(actions =>
+                {
+                    IEnumerable<PersistentMessageToSend> sentMessages = actions.GetSentMessages(batchSize: 250)
+                        .TakeWhile(x => (purgeLimit == null || !x.Bookmark.Equals(purgeLimit))
+                            && (!Configuration.EnableOutgoingMessageHistory || (DateTime.Now - x.SentAt) > Configuration.OldestMessageInOutgoingHistory));
+
+                    foreach (var sentMessage in sentMessages)
+                    {
+                        foundMessages = true;
+                        logger.DebugFormat("Purging sent message {0} to {1}/{2}/{3}", sentMessage.Id, sentMessage.Endpoint,
+                                           sentMessage.Queue, sentMessage.SubQueue);
+                        actions.DeleteMessageToSendHistoric(sentMessage.Bookmark);
+                    }
+
+                    actions.Commit();
+                });
+            } while (foundMessages);
         }
 
         private void PurgeOldestReceivedMessageIds()
@@ -188,7 +246,9 @@ namespace Rhino.Queues
             {
                 queueStorage.Global(actions =>
                 {
-                    deletedMessageIds = actions.DeleteOldestReceivedMessageIds(NumberOfReceivedMessagesToKeep, 10).ToList();
+                    deletedMessageIds = actions.DeleteOldestReceivedMessageIds(
+                        Configuration.NumberOfReceivedMessageIdsToKeep, numberOfItemsToDelete: 250)
+                        .ToList();
                     actions.Commit();
                 });
                 receivedMsgs.Remove(deletedMessageIds);
@@ -198,28 +258,28 @@ namespace Rhino.Queues
             logger.InfoFormat("Purged {0} message ids", totalCount);
         }
 
-	    private void HandleRecovery()
-		{
-			var recoveryRequired = false;
-			queueStorage.Global(actions =>
-			{
-				actions.MarkAllOutgoingInFlightMessagesAsReadyToSend();
-				actions.MarkAllProcessedMessagesWithTransactionsNotRegisterForRecoveryAsReadyToDeliver();
-				foreach (var bytes in actions.GetRecoveryInformation())
-				{
-					recoveryRequired = true;
-					TransactionManager.Reenlist(queueStorage.Id, bytes,
-						new TransactionEnlistment(queueStorage, () => { }, () => { }));
-				}
-				actions.Commit();
-			});
-			if (recoveryRequired)
-				TransactionManager.RecoveryComplete(queueStorage.Id);
-		}
+        private void HandleRecovery()
+        {
+            var recoveryRequired = false;
+            queueStorage.Global(actions =>
+            {
+                actions.MarkAllOutgoingInFlightMessagesAsReadyToSend();
+                actions.MarkAllProcessedMessagesWithTransactionsNotRegisterForRecoveryAsReadyToDeliver();
+                foreach (var bytes in actions.GetRecoveryInformation())
+                {
+                    recoveryRequired = true;
+                    TransactionManager.Reenlist(queueStorage.Id, bytes,
+                        new TransactionEnlistment(queueStorage, () => { }, () => { }));
+                }
+                actions.Commit();
+            });
+            if (recoveryRequired)
+                TransactionManager.RecoveryComplete(queueStorage.Id);
+        }
 
         public void EnablePerformanceCounters()
         {
-            if(wasStarted)
+            if (wasStarted)
                 throw new InvalidOperationException("Performance counters cannot be enabled after the queue has been started.");
 
             monitor = new PerformanceMonitor(this);
@@ -234,56 +294,56 @@ namespace Rhino.Queues
         }
 
         public string Path
-		{
-			get { return path; }
-		}
+        {
+            get { return path; }
+        }
 
-		public IPEndPoint Endpoint
-		{
-			get { return endpoint; }
-		}
+        public IPEndPoint Endpoint
+        {
+            get { return endpoint; }
+        }
 
-		#region IDisposable Members
+        #region IDisposable Members
 
-		public void Dispose()
-		{
-			if (wasDisposed)
-				return;
+        public void Dispose()
+        {
+            if (wasDisposed)
+                return;
 
-			DisposeResourcesWhoseDisposalCannotFail();
+            DisposeResourcesWhoseDisposalCannotFail();
 
             if (monitor != null)
                 monitor.Dispose();
-            
+
             queueStorage.Dispose();
 
-			// only after we finish incoming recieves, and finish processing
-			// active transactions can we mark it as disposed
-			wasDisposed = true;
-		}
+            // only after we finish incoming recieves, and finish processing
+            // active transactions can we mark it as disposed
+            wasDisposed = true;
+        }
 
-		public void DisposeRudely()
-		{
-			if (wasDisposed)
-				return;
+        public void DisposeRudely()
+        {
+            if (wasDisposed)
+                return;
 
-			DisposeResourcesWhoseDisposalCannotFail();
+            DisposeResourcesWhoseDisposalCannotFail();
 
-			queueStorage.DisposeRudely();
+            queueStorage.DisposeRudely();
 
-			// only after we finish incoming recieves, and finish processing
-			// active transactions can we mark it as disposed
-			wasDisposed = true;
-		}
+            // only after we finish incoming recieves, and finish processing
+            // active transactions can we mark it as disposed
+            wasDisposed = true;
+        }
 
-	    private void DisposeResourcesWhoseDisposalCannotFail()
-		{
-			disposing = true;
+        private void DisposeResourcesWhoseDisposalCannotFail()
+        {
+            disposing = true;
 
-			lock (newMessageArrivedLock)
-			{
-				Monitor.PulseAll(newMessageArrivedLock);
-			}
+            lock (newMessageArrivedLock)
+            {
+                Monitor.PulseAll(newMessageArrivedLock);
+            }
 
             if (wasStarted)
             {
@@ -295,213 +355,213 @@ namespace Rhino.Queues
                 receiver.Dispose();
             }
 
-		    while (currentlyInCriticalReceiveStatus > 0)
-			{
-				logger.WarnFormat("Waiting for {0} messages that are currently in critical receive status", currentlyInCriticalReceiveStatus);
-				Thread.Sleep(TimeSpan.FromSeconds(1));
-			}
+            while (currentlyInCriticalReceiveStatus > 0)
+            {
+                logger.WarnFormat("Waiting for {0} messages that are currently in critical receive status", currentlyInCriticalReceiveStatus);
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
 
-			while (currentlyInsideTransaction > 0)
-			{
-				logger.WarnFormat("Waiting for {0} transactions currently running", currentlyInsideTransaction);
-				Thread.Sleep(TimeSpan.FromSeconds(1));
-			}
-		}
+            while (currentlyInsideTransaction > 0)
+            {
+                logger.WarnFormat("Waiting for {0} transactions currently running", currentlyInsideTransaction);
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+        }
 
-		#endregion
+        #endregion
 
-		private void AssertNotDisposed()
-		{
-			if (wasDisposed)
-				throw new ObjectDisposedException("QueueManager");
-		}
+        private void AssertNotDisposed()
+        {
+            if (wasDisposed)
+                throw new ObjectDisposedException("QueueManager");
+        }
 
 
-		private void AssertNotDisposedOrDisposing()
-		{
-			if (disposing || wasDisposed)
-				throw new ObjectDisposedException("QueueManager");
-		}
+        private void AssertNotDisposedOrDisposing()
+        {
+            if (disposing || wasDisposed)
+                throw new ObjectDisposedException("QueueManager");
+        }
 
-	    public void WaitForAllMessagesToBeSent()
-		{
-			waitingForAllMessagesToBeSent = true;
-			try
-			{
-				var hasMessagesToSend = true;
-				do
-				{
-					queueStorage.Send(actions =>
-					{
-						hasMessagesToSend = actions.HasMessagesToSend();
-						actions.Commit();
-					});
-					if (hasMessagesToSend)
-						Thread.Sleep(100);
-				} while (hasMessagesToSend);
-			}
-			finally
-			{
-				waitingForAllMessagesToBeSent = false;
-			}
-		}
+        public void WaitForAllMessagesToBeSent()
+        {
+            waitingForAllMessagesToBeSent = true;
+            try
+            {
+                var hasMessagesToSend = true;
+                do
+                {
+                    queueStorage.Send(actions =>
+                    {
+                        hasMessagesToSend = actions.HasMessagesToSend();
+                        actions.Commit();
+                    });
+                    if (hasMessagesToSend)
+                        Thread.Sleep(100);
+                } while (hasMessagesToSend);
+            }
+            finally
+            {
+                waitingForAllMessagesToBeSent = false;
+            }
+        }
 
-		public IQueue GetQueue(string queue)
-		{
-			return new Queue(this, queue);
-		}
+        public IQueue GetQueue(string queue)
+        {
+            return new Queue(this, queue);
+        }
 
-		public PersistentMessage[] GetAllMessages(string queueName, string subqueue)
-		{
-			AssertNotDisposedOrDisposing();
-			PersistentMessage[] messages = null;
-			queueStorage.Global(actions =>
-			{
-				messages = actions.GetQueue(queueName).GetAllMessages(subqueue).ToArray();
-				actions.Commit();
-			});
-			return messages;
-		}
+        public PersistentMessage[] GetAllMessages(string queueName, string subqueue)
+        {
+            AssertNotDisposedOrDisposing();
+            PersistentMessage[] messages = null;
+            queueStorage.Global(actions =>
+            {
+                messages = actions.GetQueue(queueName).GetAllMessages(subqueue).ToArray();
+                actions.Commit();
+            });
+            return messages;
+        }
 
-		public HistoryMessage[] GetAllProcessedMessages(string queueName)
-		{
-			AssertNotDisposedOrDisposing();
-			HistoryMessage[] messages = null;
-			queueStorage.Global(actions =>
-			{
-				messages = actions.GetQueue(queueName).GetAllProcessedMessages().ToArray();
-				actions.Commit();
-			});
-			return messages;
-		}
+        public HistoryMessage[] GetAllProcessedMessages(string queueName)
+        {
+            AssertNotDisposedOrDisposing();
+            HistoryMessage[] messages = null;
+            queueStorage.Global(actions =>
+            {
+                messages = actions.GetQueue(queueName).GetAllProcessedMessages().ToArray();
+                actions.Commit();
+            });
+            return messages;
+        }
 
-		public PersistentMessageToSend[] GetAllSentMessages()
-		{
-			AssertNotDisposedOrDisposing();
-			PersistentMessageToSend[] msgs = null;
-			queueStorage.Global(actions =>
-			{
-				msgs = actions.GetSentMessages().ToArray();
+        public PersistentMessageToSend[] GetAllSentMessages()
+        {
+            AssertNotDisposedOrDisposing();
+            PersistentMessageToSend[] msgs = null;
+            queueStorage.Global(actions =>
+            {
+                msgs = actions.GetSentMessages().ToArray();
 
-				actions.Commit();
-			});
-			return msgs;
-		}
+                actions.Commit();
+            });
+            return msgs;
+        }
 
-		public PersistentMessageToSend[] GetMessagesCurrentlySending()
-		{
-			AssertNotDisposedOrDisposing();
-			PersistentMessageToSend[] msgs = null;
-			queueStorage.Send(actions =>
-			{
-				msgs = actions.GetMessagesToSend().ToArray();
+        public PersistentMessageToSend[] GetMessagesCurrentlySending()
+        {
+            AssertNotDisposedOrDisposing();
+            PersistentMessageToSend[] msgs = null;
+            queueStorage.Send(actions =>
+            {
+                msgs = actions.GetMessagesToSend().ToArray();
 
-				actions.Commit();
-			});
-			return msgs;
-		}
+                actions.Commit();
+            });
+            return msgs;
+        }
 
-		public Message Peek(string queueName)
-		{
-			return Peek(queueName, null, TimeSpan.FromDays(1));
-		}
+        public Message Peek(string queueName)
+        {
+            return Peek(queueName, null, TimeSpan.FromDays(1));
+        }
 
-		public Message Peek(string queueName, TimeSpan timeout)
-		{
-			return Peek(queueName, null, timeout);
-		}
+        public Message Peek(string queueName, TimeSpan timeout)
+        {
+            return Peek(queueName, null, timeout);
+        }
 
-		public Message Peek(string queueName, string subqueue)
-		{
-			return Peek(queueName, subqueue, TimeSpan.FromDays(1));
-		}
+        public Message Peek(string queueName, string subqueue)
+        {
+            return Peek(queueName, subqueue, TimeSpan.FromDays(1));
+        }
 
-		public Message Peek(string queueName, string subqueue, TimeSpan timeout)
-		{
-			var remaining = timeout;
-			while (true)
-			{
-				var message = PeekMessageFromQueue(queueName, subqueue);
-				if (message != null)
-					return message;
+        public Message Peek(string queueName, string subqueue, TimeSpan timeout)
+        {
+            var remaining = timeout;
+            while (true)
+            {
+                var message = PeekMessageFromQueue(queueName, subqueue);
+                if (message != null)
+                    return message;
 
-				lock (newMessageArrivedLock)
-				{
-					message = PeekMessageFromQueue(queueName, subqueue);
-					if (message != null)
-						return message;
+                lock (newMessageArrivedLock)
+                {
+                    message = PeekMessageFromQueue(queueName, subqueue);
+                    if (message != null)
+                        return message;
 
-					var sp = Stopwatch.StartNew();
-					if (Monitor.Wait(newMessageArrivedLock, remaining) == false)
-						throw new TimeoutException("No message arrived in the specified timeframe " + timeout);
-					remaining = Max(TimeSpan.Zero, remaining - sp.Elapsed);
-				}
-			}
-		}
+                    var sp = Stopwatch.StartNew();
+                    if (Monitor.Wait(newMessageArrivedLock, remaining) == false)
+                        throw new TimeoutException("No message arrived in the specified timeframe " + timeout);
+                    remaining = Max(TimeSpan.Zero, remaining - sp.Elapsed);
+                }
+            }
+        }
 
-		private static TimeSpan Max(TimeSpan x, TimeSpan y)
-		{
-			return x >= y ? x : y;
-		}
+        private static TimeSpan Max(TimeSpan x, TimeSpan y)
+        {
+            return x >= y ? x : y;
+        }
 
-		public Message Receive(string queueName)
-		{
-			return Receive(queueName, null, TimeSpan.FromDays(1));
-		}
+        public Message Receive(string queueName)
+        {
+            return Receive(queueName, null, TimeSpan.FromDays(1));
+        }
 
-		public Message Receive(string queueName, TimeSpan timeout)
-		{
-			return Receive(queueName, null, timeout);
-		}
+        public Message Receive(string queueName, TimeSpan timeout)
+        {
+            return Receive(queueName, null, timeout);
+        }
 
-		public Message Receive(string queueName, string subqueue)
-		{
-			return Receive(queueName, subqueue, TimeSpan.FromDays(1));
-		}
+        public Message Receive(string queueName, string subqueue)
+        {
+            return Receive(queueName, subqueue, TimeSpan.FromDays(1));
+        }
 
-		public Message Receive(string queueName, string subqueue, TimeSpan timeout)
-		{
-			EnsureEnslistment();
+        public Message Receive(string queueName, string subqueue, TimeSpan timeout)
+        {
+            EnsureEnslistment();
 
-			var remaining = timeout;
-			while (true)
-			{
-				var message = GetMessageFromQueue(queueName, subqueue);
+            var remaining = timeout;
+            while (true)
+            {
+                var message = GetMessageFromQueue(queueName, subqueue);
                 if (message != null)
                 {
                     OnMessageReceived(message);
                     return message;
                 }
-			    lock (newMessageArrivedLock)
-				{
-					message = GetMessageFromQueue(queueName, subqueue);
+                lock (newMessageArrivedLock)
+                {
+                    message = GetMessageFromQueue(queueName, subqueue);
                     if (message != null)
                     {
                         OnMessageReceived(message);
                         return message;
                     }
-				    var sp = Stopwatch.StartNew();
-					if (Monitor.Wait(newMessageArrivedLock, remaining) == false)
-						throw new TimeoutException("No message arrived in the specified timeframe " + timeout);
-				    var newRemaining = remaining - sp.Elapsed;
-				    remaining = newRemaining >= TimeSpan.Zero ? newRemaining : TimeSpan.Zero;
-				}
-			}
-		}
+                    var sp = Stopwatch.StartNew();
+                    if (Monitor.Wait(newMessageArrivedLock, remaining) == false)
+                        throw new TimeoutException("No message arrived in the specified timeframe " + timeout);
+                    var newRemaining = remaining - sp.Elapsed;
+                    remaining = newRemaining >= TimeSpan.Zero ? newRemaining : TimeSpan.Zero;
+                }
+            }
+        }
 
-		public MessageId Send(Uri uri, MessagePayload payload)
-		{
-			if (waitingForAllMessagesToBeSent)
-				throw new CannotSendWhileWaitingForAllMessagesToBeSentException("Currently waiting for all messages to be sent, so we cannot send. You probably have a race condition in your application.");
+        public MessageId Send(Uri uri, MessagePayload payload)
+        {
+            if (waitingForAllMessagesToBeSent)
+                throw new CannotSendWhileWaitingForAllMessagesToBeSentException("Currently waiting for all messages to be sent, so we cannot send. You probably have a race condition in your application.");
 
-			EnsureEnslistment();
+            EnsureEnslistment();
             var parts = uri.AbsolutePath.Substring(1).Split('/');
-			var queue = parts[0];
-			string subqueue = null;
-			if (parts.Length > 1)
-			{
-				subqueue = string.Join("/", parts.Skip(1).ToArray());
-			}
+            var queue = parts[0];
+            string subqueue = null;
+            if (parts.Length > 1)
+            {
+                subqueue = string.Join("/", parts.Skip(1).ToArray());
+            }
 
             Guid msgId = Guid.Empty;
 
@@ -509,20 +569,20 @@ namespace Rhino.Queues
             if (port == -1)
                 port = 2200;
             var destination = new Endpoint(uri.Host, port);
-            
+
             queueStorage.Global(actions =>
-			{
-			    msgId = actions.RegisterToSend(destination, queue,
-											   subqueue, payload, Enlistment.Id);
+            {
+                msgId = actions.RegisterToSend(destination, queue,
+                                               subqueue, payload, Enlistment.Id);
 
-				actions.Commit();
-			});
+                actions.Commit();
+            });
 
-		    var messageId = new MessageId
-		                        {
-		                            SourceInstanceId = queueStorage.Id,
-		                            MessageIdentifier = msgId
-		                        };
+            var messageId = new MessageId
+                                {
+                                    SourceInstanceId = queueStorage.Id,
+                                    MessageIdentifier = msgId
+                                };
             var message = new Message
             {
                 Id = messageId,
@@ -535,248 +595,238 @@ namespace Rhino.Queues
             OnMessageQueuedForSend(new MessageEventArgs(destination, message));
 
             return messageId;
-		}
+        }
 
-		private void EnsureEnslistment()
-		{
-			AssertNotDisposedOrDisposing();
+        private void EnsureEnslistment()
+        {
+            AssertNotDisposedOrDisposing();
 
-			if (Transaction.Current == null)
-				throw new InvalidOperationException("You must use TransactionScope when using Rhino.Queues");
+            if (Transaction.Current == null)
+                throw new InvalidOperationException("You must use TransactionScope when using Rhino.Queues");
 
-			if (CurrentlyEnslistedTransaction == Transaction.Current)
-				return;
-			// need to change the enslitment
-#pragma warning disable 420
-			Interlocked.Increment(ref currentlyInsideTransaction);
-#pragma warning restore 420
-			Enlistment = new TransactionEnlistment(queueStorage, () =>
-			{
-				lock (newMessageArrivedLock)
-				{
-					Monitor.PulseAll(newMessageArrivedLock);
-				}
-#pragma warning disable 420
-				Interlocked.Decrement(ref currentlyInsideTransaction);
-#pragma warning restore 420
-			}, AssertNotDisposed);
-			CurrentlyEnslistedTransaction = Transaction.Current;
-		}
+            if (CurrentlyEnslistedTransaction == Transaction.Current)
+                return;
+            // need to change the enslitment
+            Interlocked.Increment(ref currentlyInsideTransaction);
+            Enlistment = new TransactionEnlistment(queueStorage, () =>
+            {
+                lock (newMessageArrivedLock)
+                {
+                    Monitor.PulseAll(newMessageArrivedLock);
+                }
+                Interlocked.Decrement(ref currentlyInsideTransaction);
+            }, AssertNotDisposed);
+            CurrentlyEnslistedTransaction = Transaction.Current;
+        }
 
-		private PersistentMessage GetMessageFromQueue(string queueName, string subqueue)
-		{
-			AssertNotDisposedOrDisposing();
-			PersistentMessage message = null;
-			queueStorage.Global(actions =>
-			{
-				message = actions.GetQueue(queueName).Dequeue(subqueue);
+        private PersistentMessage GetMessageFromQueue(string queueName, string subqueue)
+        {
+            AssertNotDisposedOrDisposing();
+            PersistentMessage message = null;
+            queueStorage.Global(actions =>
+            {
+                message = actions.GetQueue(queueName).Dequeue(subqueue);
 
-				if (message != null)
-				{
-					actions.RegisterUpdateToReverse(
-						Enlistment.Id,
-						message.Bookmark,
-						MessageStatus.ReadyToDeliver,
-						subqueue);
-				}
+                if (message != null)
+                {
+                    actions.RegisterUpdateToReverse(
+                        Enlistment.Id,
+                        message.Bookmark,
+                        MessageStatus.ReadyToDeliver,
+                        subqueue);
+                }
 
-				actions.Commit();
-			});
-			return message;
-		}
+                actions.Commit();
+            });
+            return message;
+        }
 
-		private PersistentMessage PeekMessageFromQueue(string queueName, string subqueue)
-		{
-			AssertNotDisposedOrDisposing();
-			PersistentMessage message = null;
-			queueStorage.Global(actions =>
-			{
-				message = actions.GetQueue(queueName).Peek(subqueue);
+        private PersistentMessage PeekMessageFromQueue(string queueName, string subqueue)
+        {
+            AssertNotDisposedOrDisposing();
+            PersistentMessage message = null;
+            queueStorage.Global(actions =>
+            {
+                message = actions.GetQueue(queueName).Peek(subqueue);
 
-				actions.Commit();
-			});
-			if (message != null)
-			{
-				logger.DebugFormat("Peeked message with id '{0}' from '{1}/{2}'",
-								   message.Id, queueName, subqueue);
-			}
-			return message;
-		}
+                actions.Commit();
+            });
+            if (message != null)
+            {
+                logger.DebugFormat("Peeked message with id '{0}' from '{1}/{2}'",
+                                   message.Id, queueName, subqueue);
+            }
+            return message;
+        }
 
-		protected virtual IMessageAcceptance AcceptMessages(Message[] msgs)
-		{
-			var bookmarks = new List<MessageBookmark>();
-			queueStorage.Global(actions =>
-			{
-				foreach (var msg in receivedMsgs.Filter(msgs, message => message.Id))
-				{
-					var queue = actions.GetQueue(msg.Queue);
-					var bookmark = queue.Enqueue(msg);
-					bookmarks.Add(bookmark);
-				}
-				actions.Commit();
-			});
-			return new MessageAcceptance(this, bookmarks, msgs, queueStorage);
-		}
+        protected virtual IMessageAcceptance AcceptMessages(Message[] msgs)
+        {
+            var bookmarks = new List<MessageBookmark>();
+            queueStorage.Global(actions =>
+            {
+                foreach (var msg in receivedMsgs.Filter(msgs, message => message.Id))
+                {
+                    var queue = actions.GetQueue(msg.Queue);
+                    var bookmark = queue.Enqueue(msg);
+                    bookmarks.Add(bookmark);
+                }
+                actions.Commit();
+            });
+            return new MessageAcceptance(this, bookmarks, msgs, queueStorage);
+        }
 
-		#region Nested type: MessageAcceptance
+        #region Nested type: MessageAcceptance
 
-		private class MessageAcceptance : IMessageAcceptance
-		{
-			private readonly IList<MessageBookmark> bookmarks;
-			private readonly IEnumerable<Message> messages;
-			private readonly QueueManager parent;
-			private readonly QueueStorage queueStorage;
+        private class MessageAcceptance : IMessageAcceptance
+        {
+            private readonly IList<MessageBookmark> bookmarks;
+            private readonly IEnumerable<Message> messages;
+            private readonly QueueManager parent;
+            private readonly QueueStorage queueStorage;
 
-			public MessageAcceptance(QueueManager parent,
-				IList<MessageBookmark> bookmarks,
-				IEnumerable<Message> messages,
-				QueueStorage queueStorage)
-			{
-				this.parent = parent;
-				this.bookmarks = bookmarks;
-				this.messages = messages;
-				this.queueStorage = queueStorage;
-#pragma warning disable 420
-				Interlocked.Increment(ref parent.currentlyInCriticalReceiveStatus);
-#pragma warning restore 420
-			}
+            public MessageAcceptance(QueueManager parent,
+                IList<MessageBookmark> bookmarks,
+                IEnumerable<Message> messages,
+                QueueStorage queueStorage)
+            {
+                this.parent = parent;
+                this.bookmarks = bookmarks;
+                this.messages = messages;
+                this.queueStorage = queueStorage;
+                Interlocked.Increment(ref parent.currentlyInCriticalReceiveStatus);
+            }
 
-			#region IMessageAcceptance Members
+            #region IMessageAcceptance Members
 
-			public void Commit()
-			{
-				try
-				{
-					parent.AssertNotDisposed();
-					queueStorage.Global(actions =>
-					{
-						foreach (var bookmark in bookmarks)
-						{
-							actions.GetQueue(bookmark.QueueName)
-								.SetMessageStatus(bookmark, MessageStatus.ReadyToDeliver);
-						}
-						foreach (var msg in messages)
-						{
-							actions.MarkReceived(msg.Id);
-						}
-						actions.Commit();
-					});
-					parent.receivedMsgs.Add(messages.Select(m => m.Id));
+            public void Commit()
+            {
+                try
+                {
+                    parent.AssertNotDisposed();
+                    queueStorage.Global(actions =>
+                    {
+                        foreach (var bookmark in bookmarks)
+                        {
+                            actions.GetQueue(bookmark.QueueName)
+                                .SetMessageStatus(bookmark, MessageStatus.ReadyToDeliver);
+                        }
+                        foreach (var msg in messages)
+                        {
+                            actions.MarkReceived(msg.Id);
+                        }
+                        actions.Commit();
+                    });
+                    parent.receivedMsgs.Add(messages.Select(m => m.Id));
 
                     foreach (var msg in messages)
                     {
                         parent.OnMessageQueuedForReceive(msg);
                     }
-                    
+
                     lock (parent.newMessageArrivedLock)
-					{
-						Monitor.PulseAll(parent.newMessageArrivedLock);
-					}
-				}
-				finally
-				{
-#pragma warning disable 420
-					Interlocked.Decrement(ref parent.currentlyInCriticalReceiveStatus);
-#pragma warning restore 420
+                    {
+                        Monitor.PulseAll(parent.newMessageArrivedLock);
+                    }
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref parent.currentlyInCriticalReceiveStatus);
 
-				}
-			}
+                }
+            }
 
-			public void Abort()
-			{
-				try
-				{
-					parent.AssertNotDisposed();
-					queueStorage.Global(actions =>
-					{
-						foreach (var bookmark in bookmarks)
-						{
-							actions.GetQueue(bookmark.QueueName)
-								.Discard(bookmark);
-						}
-						actions.Commit();
-					});
-				}
-				finally
-				{
-#pragma warning disable 420
-					Interlocked.Decrement(ref parent.currentlyInCriticalReceiveStatus);
-#pragma warning restore 420
-				}
-			}
+            public void Abort()
+            {
+                try
+                {
+                    parent.AssertNotDisposed();
+                    queueStorage.Global(actions =>
+                    {
+                        foreach (var bookmark in bookmarks)
+                        {
+                            actions.GetQueue(bookmark.QueueName)
+                                .Discard(bookmark);
+                        }
+                        actions.Commit();
+                    });
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref parent.currentlyInCriticalReceiveStatus);
+                }
+            }
 
-			#endregion
-		}
+            #endregion
+        }
 
-		#endregion
+        #endregion
 
-		public void CreateQueues(params string[] queueNames)
-		{
-			AssertNotDisposedOrDisposing();
+        public void CreateQueues(params string[] queueNames)
+        {
+            AssertNotDisposedOrDisposing();
 
-			queueStorage.Global(actions =>
-			{
-				foreach (var queueName in queueNames)
-				{
-					actions.CreateQueueIfDoesNotExists(queueName);
-				}
+            queueStorage.Global(actions =>
+            {
+                foreach (var queueName in queueNames)
+                {
+                    actions.CreateQueueIfDoesNotExists(queueName);
+                }
 
-				actions.Commit();
-			});
-		}
+                actions.Commit();
+            });
+        }
 
-		public string[] Queues
-		{
-			get
-			{
-				AssertNotDisposedOrDisposing();
-				string[] queues = null;
-				queueStorage.Global(actions =>
-				{
-					queues = actions.GetAllQueuesNames();
+        public string[] Queues
+        {
+            get
+            {
+                AssertNotDisposedOrDisposing();
+                string[] queues = null;
+                queueStorage.Global(actions =>
+                {
+                    queues = actions.GetAllQueuesNames();
 
-					actions.Commit();
-				});
-				return queues;
-			}
-		}
+                    actions.Commit();
+                });
+                return queues;
+            }
+        }
 
-		public void MoveTo(string subqueue, Message message)
-		{
-			AssertNotDisposedOrDisposing();
-			EnsureEnslistment();
+        public void MoveTo(string subqueue, Message message)
+        {
+            AssertNotDisposedOrDisposing();
+            EnsureEnslistment();
 
-			queueStorage.Global(actions =>
-			{
-				var queue = actions.GetQueue(message.Queue);
-				var bookmark = queue.MoveTo(subqueue, (PersistentMessage)message);
-				actions.RegisterUpdateToReverse(Enlistment.Id,
-					bookmark, MessageStatus.ReadyToDeliver,
-					message.SubQueue
-					);
-				actions.Commit();
-			});
+            queueStorage.Global(actions =>
+            {
+                var queue = actions.GetQueue(message.Queue);
+                var bookmark = queue.MoveTo(subqueue, (PersistentMessage)message);
+                actions.RegisterUpdateToReverse(Enlistment.Id,
+                    bookmark, MessageStatus.ReadyToDeliver,
+                    message.SubQueue
+                    );
+                actions.Commit();
+            });
 
-            if(((PersistentMessage)message).Status == MessageStatus.ReadyToDeliver)
+            if (((PersistentMessage)message).Status == MessageStatus.ReadyToDeliver)
                 OnMessageReceived(message);
 
-		    var updatedMessage = new Message
-		                             {
-		                                 Id = message.Id,
-		                                 Data = message.Data,
-		                                 Headers = message.Headers,
-		                                 Queue = message.Queue,
-		                                 SubQueue = subqueue,
-		                                 SentAt = message.SentAt
-		                             };
-		
-            OnMessageQueuedForReceive(updatedMessage);
-		}
+            var updatedMessage = new Message
+                                     {
+                                         Id = message.Id,
+                                         Data = message.Data,
+                                         Headers = message.Headers,
+                                         Queue = message.Queue,
+                                         SubQueue = subqueue,
+                                         SentAt = message.SentAt
+                                     };
 
-		public void EnqueueDirectlyTo(string queue, string subqueue, MessagePayload payload)
-		{
-			EnsureEnslistment();
+            OnMessageQueuedForReceive(updatedMessage);
+        }
+
+        public void EnqueueDirectlyTo(string queue, string subqueue, MessagePayload payload)
+        {
+            EnsureEnslistment();
 
             var message = new PersistentMessage
             {
@@ -792,70 +842,70 @@ namespace Rhino.Queues
                 SubQueue = subqueue,
                 Status = MessageStatus.EnqueueWait
             };
-            
+
             queueStorage.Global(actions =>
-			{
-				var queueActions = actions.GetQueue(queue);
+            {
+                var queueActions = actions.GetQueue(queue);
 
-			    var bookmark = queueActions.Enqueue(message);
-				actions.RegisterUpdateToReverse(Enlistment.Id, bookmark, MessageStatus.EnqueueWait, subqueue);
+                var bookmark = queueActions.Enqueue(message);
+                actions.RegisterUpdateToReverse(Enlistment.Id, bookmark, MessageStatus.EnqueueWait, subqueue);
 
-				actions.Commit();
-			});
+                actions.Commit();
+            });
 
             OnMessageQueuedForReceive(message);
 
-			lock (newMessageArrivedLock)
-			{
-				Monitor.PulseAll(newMessageArrivedLock);
-			}
-		}
+            lock (newMessageArrivedLock)
+            {
+                Monitor.PulseAll(newMessageArrivedLock);
+            }
+        }
 
-		public PersistentMessage PeekById(string queueName, MessageId id)
-		{
-			PersistentMessage message = null;
-			queueStorage.Global(actions =>
-			{
-				var queue = actions.GetQueue(queueName);
+        public PersistentMessage PeekById(string queueName, MessageId id)
+        {
+            PersistentMessage message = null;
+            queueStorage.Global(actions =>
+            {
+                var queue = actions.GetQueue(queueName);
 
-				message = queue.PeekById(id);
+                message = queue.PeekById(id);
 
-				actions.Commit();
-			});
-			return message;
-		}
+                actions.Commit();
+            });
+            return message;
+        }
 
-		public string[] GetSubqueues(string queueName)
-		{
-			string[] result = null;
-			queueStorage.Global(actions =>
-			{
-				var queue = actions.GetQueue(queueName);
+        public string[] GetSubqueues(string queueName)
+        {
+            string[] result = null;
+            queueStorage.Global(actions =>
+            {
+                var queue = actions.GetQueue(queueName);
 
-				result = queue.Subqueues;
+                result = queue.Subqueues;
 
-				actions.Commit();
-			});
-			return result;
-		}
+                actions.Commit();
+            });
+            return result;
+        }
 
-		public int GetNumberOfMessages(string queueName)
-		{
-			int numberOfMsgs = 0;
-			queueStorage.Global(actions =>
-			{
-				numberOfMsgs = actions.GetNumberOfMessages(queueName);
-				actions.Commit();
-			});
-			return numberOfMsgs;
-		}
+        public int GetNumberOfMessages(string queueName)
+        {
+            int numberOfMsgs = 0;
+            queueStorage.Global(actions =>
+            {
+                numberOfMsgs = actions.GetNumberOfMessages(queueName);
+                actions.Commit();
+            });
+            return numberOfMsgs;
+        }
 
-		public void FailedToSendTo(Endpoint endpointThatWeFailedToSendTo)
-		{
-			var action = FailedToSendMessagesTo;
-			if (action != null)
-				action(endpointThatWeFailedToSendTo);
-		}
+        public void FailedToSendTo(Endpoint endpointThatWeFailedToSendTo)
+        {
+            var action = FailedToSendMessagesTo;
+            if (action != null)
+                action(endpointThatWeFailedToSendTo);
+        }
 
         public void OnMessageQueuedForSend(MessageEventArgs messageEventArgs)
         {
@@ -892,3 +942,4 @@ namespace Rhino.Queues
         }
     }
 }
+#pragma warning restore 420

--- a/Rhino.Queues/QueueManagerConfiguration.cs
+++ b/Rhino.Queues/QueueManagerConfiguration.cs
@@ -1,0 +1,73 @@
+using System;
+
+namespace Rhino.Queues
+{
+    public class QueueManagerConfiguration
+    {
+        public QueueManagerConfiguration()
+        {
+            EnableOutgoingMessageHistory = true;
+            EnableProcessedMessageHistory = true;
+            NumberOfMessagesToKeepInOutgoingHistory = 100;
+            NumberOfMessagesToKeepInProcessedHistory = 100;
+            NumberOfReceivedMessageIdsToKeep = 10000;
+            OldestMessageInOutgoingHistory = TimeSpan.FromDays(1);
+            OldestMessageInProcessedHistory = TimeSpan.FromDays(1);
+        }
+
+        /// <summary>
+        /// Enable to save sent messages to a history table after they're successfully 
+        /// sent.  Defaults to true.
+        /// </summary>
+        public bool EnableOutgoingMessageHistory { get; set; }
+
+        /// <summary>
+        /// Enable to save processed messages to a history table after being processed.
+        /// Defaults to true.
+        /// </summary>
+        public bool EnableProcessedMessageHistory { get; set; }
+
+        /// <summary>
+        /// Specifies the minimum number of messages to keep in the outgoing message 
+        /// history, if EnableOutgoingMessageHistory is true.  Defaults to 100.
+        /// 
+        /// NOTE: There could potentially be a far greater number of messages stored in 
+        /// the history depending on how many messages are processed within the time frame
+        /// specified by OldestMessageInOutgoingHistory.
+        /// </summary>
+        public int NumberOfMessagesToKeepInOutgoingHistory { get; set; }
+
+        /// <summary>
+        /// Specifies the minimum number of messages to keep in the processed message 
+        /// history, if EnableProcessedMessageHistory is true.  Defaults to 100.
+        /// 
+        /// NOTE: There could potentially be a far greater number of messages stored in 
+        /// the history depending on how many messages are processed within the time frame
+        /// specified by OldestMessageInProcessedHistory.
+        /// </summary>
+        public int NumberOfMessagesToKeepInProcessedHistory { get; set; }
+
+        /// <summary>
+        /// Specifies the number of received message IDs to store.  This prevents 
+        /// receiving the same message twice in quick succession.  Defaults to 10000, 
+        /// after which the oldest are purged.
+        /// </summary>
+        public int NumberOfReceivedMessageIdsToKeep { get; set; }
+
+        /// <summary>
+        /// Specifies the minimum length of time to keep a sent message in history, 
+        /// if EnableOutgoingMessageHistory is true.  Defaults to one day.  This should 
+        /// be adjusted depending on the expected number of messages sent and the 
+        /// desired size of the ESENT file.
+        /// </summary>
+        public TimeSpan OldestMessageInOutgoingHistory { get; set; }
+
+        /// <summary>
+        /// Specifies the minimum length of time to keep a processed message in history, 
+        /// if EnableProcessedMessageHistory is true.  Defaults to one day.  This should 
+        /// be adjusted depending on the expected number of messages processed and the 
+        /// desired size of the ESENT file.
+        /// </summary>
+        public TimeSpan OldestMessageInProcessedHistory { get; set; }
+    }
+}

--- a/Rhino.Queues/Rhino.Queues.csproj
+++ b/Rhino.Queues/Rhino.Queues.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Protocol\StreamUtil.cs" />
     <Compile Include="Queue.cs" />
     <Compile Include="QueueManager.cs" />
+    <Compile Include="QueueManagerConfiguration.cs" />
     <Compile Include="Storage\AbstractActions.cs" />
     <Compile Include="Storage\ColumnsInformation.cs" />
     <Compile Include="Storage\EsentExtension.cs" />

--- a/Rhino.Queues/Storage/GlobalActions.cs
+++ b/Rhino.Queues/Storage/GlobalActions.cs
@@ -423,7 +423,7 @@ namespace Rhino.Queues.Storage
 			}
 		}
 
-		public IEnumerable<MessageId> DeleteOldestReceivedMessages(int numberOfItemsToKeep)
+		public IEnumerable<MessageId> DeleteOldestReceivedMessageIds(int numberOfItemsToKeep, int numberOfItemsToDelete)
 		{
 			Api.MoveAfterLast(session, recveivedMsgs);
 			try
@@ -436,7 +436,7 @@ namespace Rhino.Queues.Storage
 					yield break;
 				throw;
 			}
-			while(Api.TryMovePrevious(session, recveivedMsgs))
+			while(Api.TryMovePrevious(session, recveivedMsgs) && numberOfItemsToDelete-- > 0)
 			{
 				yield return new MessageId
 				{

--- a/Rhino.Queues/Storage/MessageBookmark.cs
+++ b/Rhino.Queues/Storage/MessageBookmark.cs
@@ -1,15 +1,52 @@
+using System;
 using Microsoft.Isam.Esent.Interop;
 
 namespace Rhino.Queues.Storage
 {
-    public class MessageBookmark
+    public class MessageBookmark : IEquatable<MessageBookmark>
     {
-        public MessageBookmark()
-        {
-            
-        }
         public string QueueName;
         public byte[] Bookmark = new byte[SystemParameters.BookmarkMost];
         public int Size = SystemParameters.BookmarkMost;
+
+        public bool Equals(MessageBookmark other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+            if (!string.Equals(QueueName, other.QueueName) || Size != other.Size)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < Size; i++)
+            {
+                if (Bookmark[i] != other.Bookmark[i])
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as MessageBookmark);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = QueueName.GetHashCode();
+                hashCode = (hashCode * 397) ^ Size;
+                hashCode = (hashCode * 397) ^ Bookmark.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 }

--- a/Rhino.Queues/Storage/QueueStorage.cs
+++ b/Rhino.Queues/Storage/QueueStorage.cs
@@ -11,18 +11,20 @@ namespace Rhino.Queues.Storage
 	{
 		private readonly ILog log = LogManager.GetLogger(typeof(QueueStorage));
 		private JET_INSTANCE instance;
-		private readonly string database;
-		private readonly string path;
-		private ColumnsInformation columnsInformation;
+	    private readonly string database;
+	    private readonly string path;
+	    private ColumnsInformation columnsInformation;
+	    private readonly QueueManagerConfiguration configuration;
 
-		private readonly ReaderWriterLockSlim usageLock = new ReaderWriterLockSlim();
+	    private readonly ReaderWriterLockSlim usageLock = new ReaderWriterLockSlim();
 
 		public Guid Id { get; private set; }
 
-		public QueueStorage(string database)
+		public QueueStorage(string database, QueueManagerConfiguration configuration)
 		{
-			this.database = database;
-			path = database;
+		    this.configuration = configuration;
+		    this.database = database;
+		    path = database;
 			if (Path.IsPathRooted(database) == false)
 				path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, database);
 			this.database = Path.Combine(path, Path.GetFileName(database));
@@ -250,7 +252,7 @@ namespace Rhino.Queues.Storage
 			{
 				if (shouldTakeLock)
 					usageLock.EnterReadLock();
-				using (var qa = new GlobalActions(instance, columnsInformation, database, Id))
+				using (var qa = new GlobalActions(instance, columnsInformation, database, Id, configuration))
 				{
 					action(qa);
 				}
@@ -269,7 +271,7 @@ namespace Rhino.Queues.Storage
 			{
 				if (shouldTakeLock)
 					usageLock.EnterReadLock();
-				using (var qa = new SenderActions(instance, columnsInformation, database, Id))
+				using (var qa = new SenderActions(instance, columnsInformation, database, Id, configuration))
 				{
 					action(qa);
 				}


### PR DESCRIPTION
Running the entire purge in a single transaction seems to be causing issues.  Since this is just cleanup of old data, I've split the operations up into smaller transactions.
